### PR TITLE
Adding examples to gh pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,20 @@
 
 ##Adding Examples
 
-1. Add an inline script to the bottom of `index.html` using the script type
+1. Choose a name for your example. If your example is about infinite scroll,
+   then you would follow the following naming conventions:
+   component name                                   -> `InfiniteScrollExample`
+   example name prop for `MultipleExamplesAndCode`  -> "infinite-scroll"
+   id of your script tag                            -> "infinite-scroll-example-script"
+2. Add an inline script to the bottom of `index.html` using the script type
    `text/jsx`. The in-browser JSX parser will parse your JSX. You must create a
-   component in the global namespace that renders your example.
-2. Add an `id` to your script tag that has the name of your example, lower
-   cased and with dashes instead of spaces, followed by "-example-script" . Example:
-   "Infinite Scroll" -> `infinite-scroll-example-script`
-3. Add the lower-cased and dashed name of your example to the array passed for the `exampleNames` prop to
+   component in the global namespace that renders your example, and has the
+   naming convention '__something__Example'.
+3. Add an `id` to your script tag that has the name of your example, lower
+   cased and with dashes instead of spaces, followed by "-example-script".
+   Example: "Infinite Scroll" -> "infinite-scroll-example-script"
+4. Add the lower-cased and dashed name of your example to the array passed for the `exampleNames` prop to
    `MultipleExamplesAndCode` when it is rendered into the
    `react-waypoint-examples` element in the last script of the page.
-4. Add a condition to the `_renderExampleComponent` method in the
-   `ExampleDemoAndCode` component, returning your component if the
-   `exampleName` matches your lower-cased and dashed example name.
+5. Add any styles for your example to the `styles` directory and require them in
+   the `head` element of `index.html`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+#[React-Waypoint Homepage](http://brigade.github.io/react-waypoint/)
+
+##Adding Examples
+
+1. Add an inline script to the bottom of `index.html` using the script type
+   `text/jsx`. The in-browser JSX parser will parse your JSX. You must create a
+   component in the global namespace that renders your example.
+2. Add an `id` to your script tag that has the name of your example, lower
+   cased and with dashes instead of spaces, followed by "-example-script" . Example:
+   "Infinite Scroll" -> `infinite-scroll-example-script`
+3. Add the lower-cased and dashed name of your example to the array passed for the `exampleNames` prop to
+   `MultipleExamplesAndCode` when it is rendered into the
+   `react-waypoint-examples` element in the last script of the page.
+4. Add a condition to the `_renderExampleComponent` method in the
+   `ExampleDemoAndCode` component, returning your component if the
+   `exampleName` matches your lower-cased and dashed example name.

--- a/index.html
+++ b/index.html
@@ -222,8 +222,8 @@ var InfiniteScrollExample = React.createClass({
     if (!this.state.isLoading) {
       return (
         <Waypoint
-            onEnter={this._loadMoreItems}
-            threshold={2.0}
+          onEnter={this._loadMoreItems}
+          threshold={2.0}
         />
       );
     }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="styles/bootstrap-theme.css">
   <link rel="stylesheet" href="styles/site.css">
   <link rel="stylesheet" href="styles/examples/basic.css">
+  <link rel="stylesheet" href="styles/examples/infinite-scroll.css">
   <script type="text/javascript"
           src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/react-with-addons.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/JSXTransformer.js"></script>
@@ -32,7 +33,8 @@
   except this little library grooves the <a
   href="https://github.com/facebook/react">React way</a>.</p>
 
-  <h2>Example</h2>
+  <h2>Examples</h2>
+    <h3>Basic Use</h3>
     <div id="react-waypoint-basic-example"></div>
     <pre>
 var PropTypes = React.PropTypes;
@@ -83,6 +85,75 @@ var BasicWaypointExample = React.createClass({
     }
 });
     </pre>
+
+    <h3>Infinite Scroll</h3>
+    <div id="react-waypoint-infinite-scroll-example"></div>
+    <pre>
+var InfiniteScrollExample = React.createClass({
+  _loadMoreItems: function() {
+    this.setState({ loading: true });
+    // Do the fetching of data here with AJAX
+    // In this fake example we just generate more image urls
+    // and set the state of 'loading' to false.
+    // ...
+  },
+
+  getInitialState: function() {
+    var initialItems = [
+      'http://lorempixel.com/output/cats-q-c-640-480-9.jpg',
+      'http://lorempixel.com/output/cats-q-c-640-480-10.jpg',
+      'http://lorempixel.com/output/technics-q-c-640-480-10.jpg',
+    ];
+    return {
+      items: initialItems,
+      loading: false,
+    };
+  },
+
+  _renderItems: function() {
+    return this.state.items.map(function(imageUrl, index) {
+      return (
+        &lt;img
+          src={imageUrl}
+          alt="CATS AND ROBOTS... "
+          key={index}
+          className="infinite-scroll-example__list-item" /&gt;
+      );
+    });
+  },
+
+  _renderLoadingMessage: function() {
+    if (this.state.loading) {
+      return (
+        &lt;p className="infinite-scroll-example__loading-message"&gt;
+          Loading...
+        &lt;/p&gt;
+      );
+    }
+  },
+
+  render: function() {
+    return (
+      &lt;div className="infinite-scroll-example"&gt;
+        &lt;p className="infinite-scroll-example__count"&gt;
+          Items Loaded: {this.state.items.length}
+        &lt;/p&gt;
+        {this._renderLoadingMessage()}
+        &lt;div className="infinite-scroll-example__scrollable-parent"&gt;
+          {this._renderItems()}
+          &lt;Waypoint
+              onEnter={this._loadMoreItems}
+              threshold={2.0}
+          /&gt;
+        &lt;/div&gt;
+        &lt;p className="infinite-scroll-example__arrow" /&gt;
+      &lt;/div&gt;
+    );
+  }
+});
+    </pre>
+
+
   <h2>Documentation</h2>
 
   <h3>Installation</h3>
@@ -178,5 +249,112 @@ var BasicWaypointExample = React.createClass({
 
 
 React.render(<BasicWaypointExample />, document.getElementById('react-waypoint-basic-example'));
+  </script>
+
+  <script type="text/jsx">
+/**
+ * Randomly return either a cat or machine image url
+ * @return {string}
+ */
+var currentIndex = 0;
+var generateItem = function() {
+  var chooseCat = Math.floor(Math.random() * 2);
+  var ind = (currentIndex % 10) + 1;
+  console.log('ind is ', ind);
+  var newImage = (chooseCat) ?
+    'http://lorempixel.com/output/cats-q-c-640-480-' + ind + '.jpg':
+    'http://lorempixel.com/output/technics-q-c-640-480-' + ind + '.jpg';
+  currentIndex++;
+  return newImage;
+}
+
+var InfiniteScrollExample = React.createClass({
+  componentWillMount: function() {
+    this.waitTime = 2; // wait two seconds
+    this.numItems = 3; // add three items
+  },
+
+  _loadMoreItems: function() {
+    this.setState({ loading: true });
+    // fake an async. ajax call with setTimeout
+    window.setTimeout(function() {
+      // add data
+      var currentItems = this.state.items;
+      for (var i = 0; i < this.numItems; i++) {
+        currentItems.push(generateItem());
+      }
+      this.setState({
+        items: currentItems,
+        loading: false,
+      });
+    }.bind(this), this.waitTime * 1000);
+  },
+
+  getInitialState: function() {
+    var initialItems = [
+      'http://lorempixel.com/output/cats-q-c-640-480-9.jpg',
+      'http://lorempixel.com/output/cats-q-c-640-480-10.jpg',
+      'http://lorempixel.com/output/technics-q-c-640-480-10.jpg',
+    ];
+    return {
+      items: initialItems,
+      loading: false,
+    };
+  },
+
+  /**
+   * @return {Object}
+   */
+  _renderItems: function() {
+    return this.state.items.map(function(imageUrl, index) {
+      return (
+        <img
+          src={imageUrl}
+          alt="CATS AND ROBOTS... "
+          key={index}
+          className="infinite-scroll-example__list-item" />
+      );
+    });
+  },
+
+  /**
+   * @return {Object}
+   */
+  _renderLoadingMessage: function() {
+    if (this.state.loading) {
+      return (
+        <p className="infinite-scroll-example__loading-message">
+          Loading...
+        </p>
+      );
+    }
+  },
+
+  /**
+   * @return {Object}
+   */
+  render: function() {
+    return (
+      <div className="infinite-scroll-example">
+        <p className="infinite-scroll-example__count">
+          Items Loaded: {this.state.items.length}
+        </p>
+        {this._renderLoadingMessage()}
+        <div className="infinite-scroll-example__scrollable-parent">
+          {this._renderItems()}
+          <Waypoint
+              onEnter={this._loadMoreItems}
+              threshold={2.0}
+          />
+        </div>
+        <p className="infinite-scroll-example__arrow" />
+      </div>
+    );
+  }
+});
+
+
+React.render(<InfiniteScrollExample />,
+document.getElementById('react-waypoint-infinite-scroll-example'));
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -269,8 +269,8 @@ var generateItem = function() {
 
 var InfiniteScrollExample = React.createClass({
   componentWillMount: function() {
-    this.waitTime = 2; // wait two seconds
-    this.numItems = 3; // add three items
+    this.secondsToWait = 2;
+    this.itemsToAdd = 3;
   },
 
   _loadMoreItems: function() {
@@ -279,14 +279,14 @@ var InfiniteScrollExample = React.createClass({
     window.setTimeout(function() {
       // add data
       var currentItems = this.state.items;
-      for (var i = 0; i < this.numItems; i++) {
+      for (var i = 0; i < this.itemsToAdd; i++) {
         currentItems.push(generateItem());
       }
       this.setState({
         items: currentItems,
         loading: false,
       });
-    }.bind(this), this.waitTime * 1000);
+    }.bind(this), this.secondsToWait * 1000);
   },
 
   getInitialState: function() {

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   <link rel="stylesheet" href="styles/bootstrap.css">
   <link rel="stylesheet" href="styles/bootstrap-theme.css">
   <link rel="stylesheet" href="styles/site.css">
+  <link rel="stylesheet" href="styles/examples/basic.css">
+  <script type="text/javascript"
+          src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/react-with-addons.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/JSXTransformer.js"></script>
+  <script src="src/waypoint.js"></script>
 </head>
 <body>
 <header class="header">
@@ -28,15 +33,56 @@
   href="https://github.com/facebook/react">React way</a>.</p>
 
   <h2>Example</h2>
+    <pre>
+var PropTypes = React.PropTypes;
 
-  <iframe
-    width="100%"
-    height="300"
-    src="http://jsfiddle.net/L4z5wcx0/7/embedded/result,js,html,css/"
-    allowfullscreen="allowfullscreen"
-    frameborder="0">
-  </iframe>
+var BasicWaypointExample = React.createClass({
+    getInitialState: function() {
+        return {};
+    },
 
+    _setMessage: function(msg) {
+        this.setState({ message: msg });
+    },
+
+    _renderMessage: function() {
+        if (!this.state.message) {
+            return;
+        }
+
+        return (
+            &lt;div className="basic-example__message"&gt;
+                {this.state.message}
+            &lt;/div&gt;
+        );
+    },
+
+    render: function() {
+        return (
+            &lt;div&gt;
+              {this._renderMessage()}
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__waypoint-line"/&gt;
+              &lt;Waypoint
+                  onEnter={this._setMessage.bind(this, 'Waypoint entered')}
+                  onLeave={this._setMessage.bind(this, 'Waypoint left')}
+                  threshold={0}
+              /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+              &lt;div className="basic-example__spacer" /&gt;
+            &lt;/div&gt;
+        );
+    }
+});
+    </pre>
+    <div id="react-waypoint-basic-example"></div>
   <h2>Documentation</h2>
 
   <h3>Installation</h3>
@@ -79,4 +125,58 @@
   <p><a
      href="https://github.com/brigade/react-waypoint/blob/master/LICENSE">MIT</a></p>
   </main>
+  <script type="text/jsx">
+var PropTypes = React.PropTypes;
+
+var BasicWaypointExample = React.createClass({
+    getInitialState: function() {
+        return {};
+    },
+
+    _setMessage: function(msg) {
+        this.setState({ message: msg });
+    },
+
+    _renderMessage: function() {
+        if (!this.state.message) {
+            return;
+        }
+
+        return (
+            <div className="basic-example__message">
+                {this.state.message}
+            </div>
+        );
+    },
+
+    render: function() {
+        return (
+            <div className="basic-example">
+              {this._renderMessage()}
+              <div className="basic-example__scrollable-parent">
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__waypoint-line"/>
+                <Waypoint
+                    onEnter={this._setMessage.bind(this, 'Waypoint entered')}
+                    onLeave={this._setMessage.bind(this, 'Waypoint left')}
+                    threshold={0}
+                />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+                <div className="basic-example__spacer" />
+              </div>
+            </div>
+        );
+    }
+});
+
+
+React.render(<BasicWaypointExample />, document.getElementById('react-waypoint-basic-example'));
+  </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
   href="https://github.com/facebook/react">React way</a>.</p>
 
   <h2>Example</h2>
+    <div id="react-waypoint-basic-example"></div>
     <pre>
 var PropTypes = React.PropTypes;
 
@@ -82,7 +83,6 @@ var BasicWaypointExample = React.createClass({
     }
 });
     </pre>
-    <div id="react-waypoint-basic-example"></div>
   <h2>Documentation</h2>
 
   <h3>Installation</h3>

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ var InfiniteScrollExample = React.createClass({
   },
 
   _loadMoreItems: function() {
-    this.setState({ loading: true });
+    this.setState({ isLoading: true });
     // fake an async. ajax call with setTimeout
     window.setTimeout(function() {
       // add data
@@ -173,7 +173,7 @@ var InfiniteScrollExample = React.createClass({
       }
       this.setState({
         items: currentItems,
-        loading: false,
+        isLoading: false,
       });
     }.bind(this), this.secondsToWait * 1000);
   },
@@ -189,7 +189,7 @@ var InfiniteScrollExample = React.createClass({
     ];
     return {
       items: initialItems,
-      loading: false,
+      isLoading: false,
     };
   },
 
@@ -212,7 +212,7 @@ var InfiniteScrollExample = React.createClass({
    * @return {Object}
    */
   _renderLoadingMessage: function() {
-    if (this.state.loading) {
+    if (this.state.isLoading) {
       return (
         <p className="infinite-scroll-example__loading-message">
           Loading...
@@ -222,7 +222,7 @@ var InfiniteScrollExample = React.createClass({
   },
 
   _renderWaypoint: function() {
-    if (!this.state.loading) {
+    if (!this.state.isLoading) {
       return (
         <Waypoint
             onEnter={this._loadMoreItems}

--- a/index.html
+++ b/index.html
@@ -260,7 +260,6 @@ var currentIndex = 0;
 var generateItem = function() {
   var chooseCat = Math.floor(Math.random() * 2);
   var ind = (currentIndex % 10) + 1;
-  console.log('ind is ', ind);
   var newImage = (chooseCat) ?
     'http://lorempixel.com/output/cats-q-c-640-480-' + ind + '.jpg':
     'http://lorempixel.com/output/technics-q-c-640-480-' + ind + '.jpg';

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
   <script id="basic-example-script" type="text/jsx">
 var PropTypes = React.PropTypes;
 
-var BasicWaypointExample = React.createClass({
+var BasicExample = React.createClass({
   /**
    * @return {Object}
    */
@@ -262,13 +262,15 @@ var ExampleDemoAndCode = React.createClass({
   },
 
   _renderExampleComponent: function() {
-    if (this.props.exampleName === 'basic') {
-      return (<BasicWaypointExample />);
-    } else if (this.props.exampleName === 'infinite-scroll') {
-      return (<InfiniteScrollExample />);
-    } else {
+    var componentName =
+      this._convertToTitle(this.props.exampleName).replace(' ', '') + 'Example';
+    // Component must be defined in the global namespace
+    var componentFunction = window[componentName];
+    if (!componentFunction) {
       throw new Error('_renderExampleComponent did not recognise this.props.exampleName');
     }
+
+    return React.createElement(componentFunction);
   },
 
   _renderExampleCode: function() {

--- a/index.html
+++ b/index.html
@@ -157,25 +157,22 @@ var generateItem = function() {
 }
 
 var InfiniteScrollExample = React.createClass({
-  componentWillMount: function() {
-    this.secondsToWait = 2;
-    this.itemsToAdd = 3;
-  },
-
   _loadMoreItems: function() {
+    var itemsToAdd = 3;
+    var secondsToWait = 2;
     this.setState({ isLoading: true });
     // fake an async. ajax call with setTimeout
     window.setTimeout(function() {
       // add data
       var currentItems = this.state.items;
-      for (var i = 0; i < this.itemsToAdd; i++) {
+      for (var i = 0; i < itemsToAdd; i++) {
         currentItems.push(generateItem());
       }
       this.setState({
         items: currentItems,
         isLoading: false,
       });
-    }.bind(this), this.secondsToWait * 1000);
+    }.bind(this), secondsToWait * 1000);
   },
 
   /**

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="styles/site.css">
   <link rel="stylesheet" href="styles/examples/basic.css">
   <link rel="stylesheet" href="styles/examples/infinite-scroll.css">
+  <link rel="stylesheet" href="styles/examples/examples.css">
   <script type="text/javascript"
           src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/react-with-addons.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/JSXTransformer.js"></script>
@@ -34,125 +35,7 @@
   href="https://github.com/facebook/react">React way</a>.</p>
 
   <h2>Examples</h2>
-    <h3>Basic Use</h3>
-    <div id="react-waypoint-basic-example"></div>
-    <pre>
-var PropTypes = React.PropTypes;
-
-var BasicWaypointExample = React.createClass({
-    getInitialState: function() {
-        return {};
-    },
-
-    _setMessage: function(msg) {
-        this.setState({ message: msg });
-    },
-
-    _renderMessage: function() {
-        if (!this.state.message) {
-            return;
-        }
-
-        return (
-            &lt;div className="basic-example__message"&gt;
-                {this.state.message}
-            &lt;/div&gt;
-        );
-    },
-
-    render: function() {
-        return (
-            &lt;div&gt;
-              {this._renderMessage()}
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__waypoint-line"/&gt;
-              &lt;Waypoint
-                  onEnter={this._setMessage.bind(this, 'Waypoint entered')}
-                  onLeave={this._setMessage.bind(this, 'Waypoint left')}
-                  threshold={0}
-              /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-              &lt;div className="basic-example__spacer" /&gt;
-            &lt;/div&gt;
-        );
-    }
-});
-    </pre>
-
-    <h3>Infinite Scroll</h3>
-    <div id="react-waypoint-infinite-scroll-example"></div>
-    <pre>
-var InfiniteScrollExample = React.createClass({
-  _loadMoreItems: function() {
-    this.setState({ loading: true });
-    // Do the fetching of data here with AJAX
-    // In this fake example we just generate more image urls
-    // and set the state of 'loading' to false.
-    // ...
-  },
-
-  getInitialState: function() {
-    var initialItems = [
-      'http://lorempixel.com/output/cats-q-c-640-480-9.jpg',
-      'http://lorempixel.com/output/cats-q-c-640-480-10.jpg',
-      'http://lorempixel.com/output/technics-q-c-640-480-10.jpg',
-    ];
-    return {
-      items: initialItems,
-      loading: false,
-    };
-  },
-
-  _renderItems: function() {
-    return this.state.items.map(function(imageUrl, index) {
-      return (
-        &lt;img
-          src={imageUrl}
-          alt="CATS AND ROBOTS... "
-          key={index}
-          className="infinite-scroll-example__list-item" /&gt;
-      );
-    });
-  },
-
-  _renderLoadingMessage: function() {
-    if (this.state.loading) {
-      return (
-        &lt;p className="infinite-scroll-example__loading-message"&gt;
-          Loading...
-        &lt;/p&gt;
-      );
-    }
-  },
-
-  render: function() {
-    return (
-      &lt;div className="infinite-scroll-example"&gt;
-        &lt;p className="infinite-scroll-example__count"&gt;
-          Items Loaded: {this.state.items.length}
-        &lt;/p&gt;
-        {this._renderLoadingMessage()}
-        &lt;div className="infinite-scroll-example__scrollable-parent"&gt;
-          {this._renderItems()}
-          &lt;Waypoint
-              onEnter={this._loadMoreItems}
-              threshold={2.0}
-          /&gt;
-        &lt;/div&gt;
-        &lt;p className="infinite-scroll-example__arrow" /&gt;
-      &lt;/div&gt;
-    );
-  }
-});
-    </pre>
-
+    <div id="react-waypoint-examples"></div>
 
   <h2>Documentation</h2>
 
@@ -196,62 +79,68 @@ var InfiniteScrollExample = React.createClass({
   <p><a
      href="https://github.com/brigade/react-waypoint/blob/master/LICENSE">MIT</a></p>
   </main>
-  <script type="text/jsx">
+  <script id="basic-example-script" type="text/jsx">
 var PropTypes = React.PropTypes;
 
 var BasicWaypointExample = React.createClass({
-    getInitialState: function() {
-        return {};
-    },
+  /**
+   * @return {Object}
+   */
+  getInitialState: function() {
+    return {};
+  },
 
-    _setMessage: function(msg) {
-        this.setState({ message: msg });
-    },
+  _setMessage: function(msg) {
+    this.setState({ message: msg });
+  },
 
-    _renderMessage: function() {
-        if (!this.state.message) {
-            return;
-        }
-
-        return (
-            <div className="basic-example__message">
-                {this.state.message}
-            </div>
-        );
-    },
-
-    render: function() {
-        return (
-            <div className="basic-example">
-              {this._renderMessage()}
-              <div className="basic-example__scrollable-parent">
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__waypoint-line"/>
-                <Waypoint
-                    onEnter={this._setMessage.bind(this, 'Waypoint entered')}
-                    onLeave={this._setMessage.bind(this, 'Waypoint left')}
-                    threshold={0}
-                />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-                <div className="basic-example__spacer" />
-              </div>
-            </div>
-        );
+  /**
+   * @return {Object}
+   */
+  _renderMessage: function() {
+    if (!this.state.message) {
+      return;
     }
+
+    return (
+      <div className="basic-example__message">
+          {this.state.message}
+      </div>
+    );
+  },
+
+  /**
+   * @return {Object}
+   */
+  render: function() {
+    return (
+      <div className="basic-example">
+        {this._renderMessage()}
+        <div className="basic-example__scrollable-parent">
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__waypoint-line"/>
+          <Waypoint
+            onEnter={this._setMessage.bind(this, 'Waypoint entered')}
+            onLeave={this._setMessage.bind(this, 'Waypoint left')}
+            threshold={0}
+          />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+          <div className="basic-example__spacer" />
+        </div>
+      </div>
+    );
+  }
 });
-
-
-React.render(<BasicWaypointExample />, document.getElementById('react-waypoint-basic-example'));
   </script>
 
-  <script type="text/jsx">
+  <script id="infinite-scroll-example-script" type="text/jsx">
 /**
  * Randomly return either a cat or machine image url
  * @return {string}
@@ -289,6 +178,9 @@ var InfiniteScrollExample = React.createClass({
     }.bind(this), this.secondsToWait * 1000);
   },
 
+  /**
+   * @return {Object}
+   */
   getInitialState: function() {
     var initialItems = [
       'http://lorempixel.com/output/cats-q-c-640-480-9.jpg',
@@ -351,9 +243,66 @@ var InfiniteScrollExample = React.createClass({
     );
   }
 });
+  </script>
 
+  <script type="text/jsx">
+var ExampleDemoAndCode = React.createClass({
+  /**
+   * @param {String} words
+   * @return {String}
+   */
+  _convertToTitle: function(words) {
+    return words.replace(/-|_/g, ' ')
+    .replace(/\b\s?(\S)/g, function(match, group) { return match.toUpperCase(); } );
+  },
 
-React.render(<InfiniteScrollExample />,
-document.getElementById('react-waypoint-infinite-scroll-example'));
+  _renderExampleComponent: function() {
+    if (this.props.exampleName === 'basic') {
+      return (<BasicWaypointExample />);
+    } else if (this.props.exampleName === 'infinite-scroll') {
+      return (<InfiniteScrollExample />);
+    } else {
+      throw new Error('_renderExampleComponent did not recognise this.props.exampleName');
+    }
+  },
+
+  _renderExampleCode: function() {
+    var scriptId = this.props.exampleName + '-example-script';
+    var exampleCodeContent = document.getElementById(scriptId).innerHTML;
+    return (
+      <pre className="react-example__code">
+{exampleCodeContent}
+      </pre>
+    );
+  },
+
+  render: function() {
+    return (
+      <div className="react-example">
+        <h3>{this._convertToTitle(this.props.exampleName)}</h3>
+        {this._renderExampleComponent()}
+        <pre>
+          {this._renderExampleCode()}
+        </pre>
+      </div>
+    );
+  }
+});
+
+var MultipleExamplesAndCode = React.createClass({
+  render: function() {
+    var examples = this.props.exampleNames.map(function(exampleName) {
+      return (<ExampleDemoAndCode exampleName={exampleName} key={exampleName} />);
+    });
+    return (
+      <div className="code-examples">
+        {examples}
+      </div>
+    );
+  }
+});
+
+React.render(<MultipleExamplesAndCode exampleNames={['basic',
+  'infinite-scroll']} />, document.getElementById('react-waypoint-examples'));
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -221,6 +221,17 @@ var InfiniteScrollExample = React.createClass({
     }
   },
 
+  _renderWaypoint: function() {
+    if (!this.state.loading) {
+      return (
+        <Waypoint
+            onEnter={this._loadMoreItems}
+            threshold={2.0}
+        />
+      );
+    }
+  },
+
   /**
    * @return {Object}
    */
@@ -233,10 +244,7 @@ var InfiniteScrollExample = React.createClass({
         {this._renderLoadingMessage()}
         <div className="infinite-scroll-example__scrollable-parent">
           {this._renderItems()}
-          <Waypoint
-              onEnter={this._loadMoreItems}
-              threshold={2.0}
-          />
+          {this._renderWaypoint()}
         </div>
         <p className="infinite-scroll-example__arrow" />
       </div>

--- a/src/waypoint.js
+++ b/src/waypoint.js
@@ -1,5 +1,3 @@
-var React = require('react');
-
 var PropTypes = React.PropTypes;
 
 /**
@@ -141,5 +139,3 @@ var Waypoint = React.createClass({
     return React.createElement('span', { style: { fontSize: 0 } });
   }
 });
-
-module.exports = Waypoint;

--- a/styles/examples/basic.css
+++ b/styles/examples/basic.css
@@ -1,0 +1,38 @@
+.basic-example {
+  border: solid 1px #cecece;
+  position: relative;
+}
+
+.basic-example__scrollable-parent {
+  max-height: 500px;
+  overflow: scroll;
+  position: relative;
+}
+
+.basic-example__spacer {
+    font-size: 40px;
+    line-height: 200px;
+    text-align: center;
+    color: #ccc;
+}
+
+.basic-example__spacer:before {
+    content: '▼';
+}
+
+.basic-example__waypoint-line {
+    border-top: 1px dashed red;
+}
+
+.basic-example__message {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    background-color: #999;
+    opacity: 0.5;
+    color: #fff;
+    padding: 10px;
+    z-index: 1000;
+}

--- a/styles/examples/basic.css
+++ b/styles/examples/basic.css
@@ -10,30 +10,30 @@
 }
 
 .basic-example__spacer {
-    font-size: 40px;
-    line-height: 200px;
-    text-align: center;
-    color: #ccc;
+  color: #ccc;
+  font-size: 40px;
+  line-height: 200px;
+  text-align: center;
 }
 
 .basic-example__spacer:before {
-    content: '▼';
+  content: '▼';
 }
 
 .basic-example__waypoint-line {
-    border-top: 1px dashed red;
+  border-top: 1px dashed red;
 }
 
 .basic-example__message {
-    background-color: #999;
-    color: #fff;
-    left: 0;
-    opacity: 0.5;
-    padding: 10px;
-    pointer-events: none;
-    position: absolute;
-    text-align: center;
-    top: 0;
-    width: 100%;
-    z-index: 1000;
+  background-color: #999;
+  color: #fff;
+  left: 0;
+  opacity: 0.5;
+  padding: 10px;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
 }

--- a/styles/examples/basic.css
+++ b/styles/examples/basic.css
@@ -25,14 +25,15 @@
 }
 
 .basic-example__message {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    text-align: center;
     background-color: #999;
-    opacity: 0.5;
     color: #fff;
+    left: 0;
+    opacity: 0.5;
     padding: 10px;
+    pointer-events: none;
+    position: absolute;
+    text-align: center;
+    top: 0;
+    width: 100%;
     z-index: 1000;
 }

--- a/styles/examples/examples.css
+++ b/styles/examples/examples.css
@@ -1,0 +1,4 @@
+pre:not(.react-example__code) {
+  /* fix border issue because React renders two nested 'pre' tags */
+  border: 1px solid #ccc;;
+}

--- a/styles/examples/infinite-scroll.css
+++ b/styles/examples/infinite-scroll.css
@@ -1,0 +1,62 @@
+.infinite-scroll-example {
+  border: solid 1px blue;
+  position: relative;
+}
+
+.infinite-scroll-example__scrollable-parent {
+  height: 500px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  position: relative;
+  margin: 0 auto;
+  max-width: 580px;
+}
+
+.infinite-scroll-example__loading-message,
+.infinite-scroll-example__count {
+  color: #fff;
+  opacity: 0.5;
+  pointer-events: none;
+  padding: 10px;
+  background-color: #999;
+  position: absolute;
+  z-index: 1000;
+}
+
+.infinite-scroll-example__arrow {
+  opacity: 0.75;
+  color: #000;
+  background-color: #fff;
+  position: absolute;
+  pointer-events: none;
+  bottom: 0;
+  text-align: center;
+  font-size: 40px;
+  line-height: 50px;
+  width: 100%;
+  z-index: 1000;
+}
+
+p.infinite-scroll-example__arrow {
+  /** override the padding added by bootstrap styles **/
+  margin: 0;
+}
+
+.infinite-scroll-example__arrow:before {
+  content: '▼';
+}
+
+.infinite-scroll-example__count {
+  right: 0;
+  top: 0;
+}
+
+.infinite-scroll-example__loading-message {
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.infinite-scroll-example__list-item {
+  max-width: 580px;
+}

--- a/styles/examples/infinite-scroll.css
+++ b/styles/examples/infinite-scroll.css
@@ -5,34 +5,34 @@
 
 .infinite-scroll-example__scrollable-parent {
   height: 500px;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  position: relative;
   margin: 0 auto;
   max-width: 580px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  position: relative;
 }
 
 .infinite-scroll-example__loading-message,
 .infinite-scroll-example__count {
+  background-color: #999;
   color: #fff;
   opacity: 0.5;
-  pointer-events: none;
   padding: 10px;
-  background-color: #999;
+  pointer-events: none;
   position: absolute;
   z-index: 1000;
 }
 
 .infinite-scroll-example__arrow {
-  opacity: 0.75;
-  color: #000;
   background-color: #fff;
-  position: absolute;
-  pointer-events: none;
   bottom: 0;
-  text-align: center;
+  color: #000;
   font-size: 40px;
   line-height: 50px;
+  opacity: 0.75;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
   width: 100%;
   z-index: 1000;
 }

--- a/styles/site.css
+++ b/styles/site.css
@@ -14,3 +14,10 @@
     margin: 0 auto;
   }
 }
+
+pre {
+  /* override bootstrap style to work with React; React creates two nested 'pre'
+   * tags when you use 'pre'
+   */
+  border-width: 0;
+}


### PR DESCRIPTION
 - Replaces the JSFiddle basic example with a live inline demo and sample code
 - Adds a live inline demo of infinite scroll

The infinite scroll demo can be referenced in an upcoming blog post/tutorial about React-Waypoint.

Notice that this pull request is to be merged with the 'gh-pages' branch, and will update the Github Pages site for this project.