### PR TITLE
Use BookmarkableHeader component in examples; fixes #6

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,55 @@ var InfiniteScrollExample = React.createClass({
   </script>
 
   <script type="text/jsx">
+var PropTypes = React.PropTypes;
+
+var BookmarkableHeader = React.createClass({
+  propTypes: {
+    headerType: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+  },
+
+  /**
+   * @return {Object}
+   */
+  _renderLink: function() {
+    return (
+      <a
+        aria-hidden
+        href={'#' + this.props.id} className="bookmarkable-header__symbol"
+      >
+        §
+      </a>
+    );
+  },
+
+  /**
+   * @return {Object}
+   */
+  _renderText: function() {
+    return (
+      <span id={this.props.id} className="bookmarkable-header__text">
+        {this.props.text}
+      </span>
+    );
+  },
+
+  /**
+   * @return {Object}
+   */
+  render: function() {
+    return (
+      React.createElement(
+        this.props.headerType,
+        { className: 'bookmarkable-header' },
+        (this._renderLink()),
+        (this._renderText())
+      )
+    );
+  }
+});
+
 var ExampleDemoAndCode = React.createClass({
   /**
    * @param {String} words
@@ -283,10 +332,19 @@ var ExampleDemoAndCode = React.createClass({
     );
   },
 
+  propTypes: {
+    headerType: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+  },
   render: function() {
     return (
       <div className="react-example">
-        <h3>{this._convertToTitle(this.props.exampleName)}</h3>
+        <BookmarkableHeader
+          headerType="h3"
+          text={this._convertToTitle(this.props.exampleName)}
+          id={this.props.exampleName}
+        />
         {this._renderExampleComponent()}
         <pre>
           {this._renderExampleCode()}

--- a/styles/examples/examples.css
+++ b/styles/examples/examples.css
@@ -2,3 +2,20 @@ pre:not(.react-example__code) {
   /* fix border issue because React renders two nested 'pre' tags */
   border: 1px solid #ccc;;
 }
+
+.bookmarkable-header {
+  position: relative;
+}
+
+.bookmarkable-header__symbol {
+  display: none;
+  margin-left: -16px;
+  padding-right: 4px;
+  position: absolute;
+  width: 16px;
+}
+
+.bookmarkable-header__symbol:hover,
+.bookmarkable-header:hover > .bookmarkable-header__symbol {
+  display: block;
+}

--- a/styles/examples/examples.css
+++ b/styles/examples/examples.css
@@ -9,9 +9,10 @@ pre:not(.react-example__code) {
 
 .bookmarkable-header__symbol {
   display: none;
-  margin-left: -16px;
+  left: -16px;
   padding-right: 4px;
   position: absolute;
+  top: 0;
   width: 16px;
 }
 


### PR DESCRIPTION
We want our examples to be bookmarkable, so this component adds
bookmarkable headers in the style of Wikipedia.

It would be nice if all our headers in the documentation were
bookmarkable - resusing the BookmarkableHeader component there would be
easy if the whole content of the page were rendered by React.

We may be re-organizing the project to use the build system, and if we
do that on the github pages branch then we can more easily split the
inline scripts into separate files. Rendering the whole page content as
a React component will follow naturally from that step. (See issue #7)