### PR TITLE
Listen to 'resize' on window, not scrollableParent; fixes #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master (unreleased)
 
+- Fix corner case where scrollable parent is not the window and the window
+  resize should trigger a Waypoint callback.
+
 ## 0.3.0
 
 - Fix Waypoints with the window element as their scrollable parent (Firefox only)

--- a/src/waypoint.js
+++ b/src/waypoint.js
@@ -30,7 +30,7 @@ var Waypoint = React.createClass({
   componentDidMount: function() {
     this.scrollableParent = this._findScrollableParent();
     this.scrollableParent.addEventListener('scroll', this._handleScroll);
-    this.scrollableParent.addEventListener('resize', this._handleScroll);
+    window.addEventListener('resize', this._handleScroll);
     this._handleScroll();
   },
 

--- a/src/waypoint.js
+++ b/src/waypoint.js
@@ -46,7 +46,7 @@ var Waypoint = React.createClass({
       //
       //   Cannot read property 'removeEventListener' of undefined
       this.scrollableParent.removeEventListener('scroll', this._handleScroll);
-      this.scrollableParent.removeEventListener('resize', this._handleScroll);
+      window.removeEventListener('resize', this._handleScroll);
     }
   },
 


### PR DESCRIPTION
(From the relevant issue:)
We listen to the 'scroll' and 'resize' events on the 'scrollableParent'
element, which is sometimes the window. However, the 'resize' event is
[only triggered on the window element][mdn-resize-event], so we may not
catch it in cases that the 'scrollableParent' is not the window.

It seems safer to listen to the 'resize' event always on the window,
rather than the scrollable parent.

[mdn-resize-event]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onresize