### PR TITLE
Add event and context

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -83,7 +83,12 @@ const Waypoint = React.createClass({
     return window;
   },
 
-  _handleScroll: function() {
+  /**
+   * @param {Object} event the native scroll event coming from the scrollable
+   *   parent, or resize event coming from the window. Will be undefined if
+   *   called by a React lifecyle method
+   */
+  _handleScroll: function(event) {
     const isVisible = this._isVisible();
 
     if (this._wasVisible === isVisible) {
@@ -92,9 +97,9 @@ const Waypoint = React.createClass({
     }
 
     if (isVisible) {
-      this.props.onEnter();
+      this.props.onEnter.call(this, event);
     } else {
-      this.props.onLeave();
+      this.props.onLeave.call(this, event);
     }
 
     this._wasVisible = isVisible;


### PR DESCRIPTION
`_handleScroll` is dispatched by scroll and resize events as well as React lifecycle events. In addition, `onEnter` and `onLeave` should be `call`ed with the context of the parent element being scrolled. These handlers aren't automatically bound to the component with ES6-based React classes, and even for ordinary `React.createClass` components, the handler would be bound to the parent element which is not necessarily the scrollable parent element that Waypoint identifies. It's useful to be able to distinguish between the events and determine the scrolling component, and this change adds no overhead or complexity.