### PR TITLE
Remove call of handleScroll() On componentDidUpdate

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -34,11 +34,6 @@ const Waypoint = React.createClass({
     this._handleScroll();
   },
 
-  componentDidUpdate: function() {
-    // The element may have moved.
-    this._handleScroll();
-  },
-
   componentWillUnmount: function() {
     if (this.scrollableParent) {
       // At the time of unmounting, the scrollable parent might no longer exist.


### PR DESCRIPTION
- This call was causing multiple onEnter() method calls resulting into
  content being loaded more than on time