### PR TITLE
Allow React 0.14.0-beta peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master (unreleased)
 
 - Add event object and scope to onEnter/onLeave calls
+- Allow React 0.14.0-beta peerDependency
 
 ## 1.0.1
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": "~0.13.x"
+    "react": "^0.13.0 || ^0.14.0-beta1"
   },
   "devDependencies": {
     "babel": "^5.1.9",


### PR DESCRIPTION
This will allow people to use react-waypoint with the 0.14.0 beta
version of React, which might be useful if you want to currently depend
on other things that require the latest beta version of React, such as
Relay.

Fixes #21