### PR TITLE
Add test to verify that onEnter is called only once

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -76,8 +76,8 @@ describe('<Waypoint>', function() {
 
     describe('when the waypoint is re-rendered', () => {
       beforeEach(() => {
-        this.parentComponent.forceUpdate();
         this.props.onEnter.calls.reset();
+        this.parentComponent.forceUpdate();
       });
 
       it('does not call the onEnter callback again', () => {

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -62,7 +62,8 @@ describe('<Waypoint>', function() {
     beforeEach(() => {
       this.topSpacerHeight = 90;
       this.bottomSpacerHeight = 200;
-      this.scrollable = this.subject().getDOMNode();
+      this.parentComponent = this.subject();
+      this.scrollable = this.parentComponent.getDOMNode();
     });
 
     it('calls the onEnter handler', () => {
@@ -71,6 +72,17 @@ describe('<Waypoint>', function() {
 
     it('does not call the onLeave handler', () => {
       expect(this.props.onLeave).not.toHaveBeenCalled();
+    });
+
+    describe('when the waypoint is re-rendered', () => {
+      beforeEach(() => {
+        this.parentComponent.forceUpdate();
+        this.props.onEnter.calls.reset();
+      });
+
+      it('does not call the onEnter callback again', () => {
+        expect(this.props.onEnter).not.toHaveBeenCalled();
+      });
     });
 
     describe('when scrolling while the waypoint is visible', () => {


### PR DESCRIPTION
We've had reports of onEnter firing multiple times while in view
(e.g. #28). I've been trying to reproduce the bug with a test, but I
can't reproduce it. I'm adding the test that I wrote anyway as it will
prevent possible regressions. It might also inspire someone else to dig
in and find other things that I didn't find.