### PR TITLE
Document some limitations in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ var Waypoint = require('react-waypoint');
   },
 ```
 
+## Limitations
+
+In this component we make a few assumptions that we believe are generally safe,
+but in some situations might present limitations.
+
+- We determine the scrollable-ness of a node by inspecting its computed
+  overflow-y or overflow property and nothing else. This could mean that a
+  container with this style but that does not actually currently scroll will be
+  considered when performing visibility calculations.
+- We assume that waypoint is rendered within at most one scrollable container.
+  If you render a waypoint in multiple nested scrollable containers, the
+  visibility calculations will likely not be accurate.
+- We also base the visibility calculations on the scroll position of the
+  scrollable container (or `window` if no scrollable container is found). This
+  means that if your scrollable container has a height that is greater than the
+  window, it might trigger `onEnter` unexpectedly.
+
 ## Credits
 
 Credit to [trotzig][trotzig-github] and [lencioni][lencioni-github] for writing


### PR DESCRIPTION
At Brigade, we recently bumped into an issue where <Waypoint> would
always call `onEnter` no matter if it was visible or not. We determined
that this was due to a change we made that caused its scrollable
container to have a height that was both larger than the window's
viewport height and so that the container did not actually scroll (it's
overflow was still set, but it's height was tall enough for whatever
content it received). We brainstormed some ideas for how to resolve this
in react-waypoint, but the we are worried about the performance
implications of the solutions. We believe that this may be enough of an
edge case that we don't actually need to solve right now, so we decided
to document this in the readme to help others who might be running into
this issue. If this becomes more of a problem for more people, we might
consider implementing a better solution in code.