### PR TITLE
Skip `<html>` when looking for scrollable ancestor

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -323,4 +323,22 @@ describe('<Waypoint>', function() {
       });
     });
   });
+
+  describe('when the <html> is the scrollable parent', () => {
+    beforeEach(() => {
+      // Give the <html> an overflow style
+      document.documentElement.style.overflow = 'auto';
+
+      // Make the normal parent non-scrollable
+      this.parentStyle = {};
+    });
+
+    afterEach(() => {
+      delete document.documentElement.style.overflow;
+    });
+
+    it('does not throw an error', () => {
+      expect(this.subject).not.toThrow();
+    });
+  });
 });

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -73,7 +73,7 @@ const Waypoint = React.createClass({
         // This particular node does not have a computed style.
         continue;
       }
-      
+
       if (node === document.documentElement) {
         // This particular node does not have a scroll bar, it uses the window.
         continue;

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -73,6 +73,11 @@ const Waypoint = React.createClass({
         // This particular node does not have a computed style.
         continue;
       }
+      
+      if (node === document.documentElement) {
+        // This particular node does not have a scroll bar, it uses the window.
+        continue;
+      }
 
       const style = window.getComputedStyle(node);
       const overflowY = style.getPropertyValue('overflow-y') ||


### PR DESCRIPTION
The `<html>` tag itself is not scrollable, it causes the window to scroll.