### PR TITLE
Fix double fire

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -309,6 +309,7 @@ describe('<Waypoint>', function() {
     });
 
     it('does not fire the onEnter handler on mount', () => {
+      this.subject();
       expect(this.props.onEnter).not.toHaveBeenCalled();
     });
 

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -342,4 +342,32 @@ describe('<Waypoint>', function() {
       expect(this.subject).not.toThrow();
     });
   });
+
+  describe('when the waypoint is updated in the onEnter callback', () => {
+    beforeEach(() => {
+      const Wrapper = React.createClass({
+        render() {
+          return React.createElement('div',
+            { style: { margin: window.innerHeight * 2 + 'px 0'} },
+            React.createElement(Waypoint, {
+              onEnter: () => {
+                this.props.onEnter();
+                this.forceUpdate();
+              }
+            })
+          );
+        },
+      });
+
+      this.subject = () => {
+        return renderAttached(React.createElement(Wrapper, this.props));
+      };
+    });
+
+    it('only calls onEnter once', () => {
+      this.subject();
+      scrollNodeTo(window, window.innerHeight);
+      expect(this.props.onEnter.calls.count()).toBe(1);
+    });
+  });
 });

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -100,21 +100,25 @@ const Waypoint = React.createClass({
    */
   _handleScroll(event) {
     const currentPosition = this._currentPosition();
+    const previousPosition = this._previousPosition;
 
-    if (this._previousPosition === currentPosition) {
+    // Save previous position as early as possible to prevent cycles
+    this._previousPosition = currentPosition;
+
+    if (previousPosition === currentPosition) {
       // No change since last trigger
       return;
     }
 
     if (currentPosition === POSITIONS.inside) {
       this.props.onEnter.call(this, event);
-    } else if (this._previousPosition === POSITIONS.inside) {
+    } else if (previousPosition === POSITIONS.inside) {
       this.props.onLeave.call(this, event);
     }
 
-    const isRapidScrollDown = this._previousPosition === POSITIONS.below &&
+    const isRapidScrollDown = previousPosition === POSITIONS.below &&
                               currentPosition === POSITIONS.above;
-    const isRapidScrollUp =   this._previousPosition === POSITIONS.above &&
+    const isRapidScrollUp =   previousPosition === POSITIONS.above &&
                               currentPosition === POSITIONS.below;
     if (isRapidScrollDown || isRapidScrollUp) {
       // If the scroll event isn't fired often enough to occur while the
@@ -122,8 +126,6 @@ const Waypoint = React.createClass({
       this.props.onEnter.call(this, event);
       this.props.onLeave.call(this, event);
     }
-
-    this._previousPosition = currentPosition;
   },
 
   /**


### PR DESCRIPTION
If your onEnter/onLeave callback made the `<Waypoint>` re-render, you
could end up with duplicate callback calls. This was because we were
remembering the previous position too late. Consider the following
example:

```
  <List>
    {items.map((item) => <Item item={item}/>)}
    <Waypoint onEnter={() => this.setState({ foo: 'bar' })}/>
  </List>
```
When the waypoint is in view, it will fire the onEnter callback. The
setState call will then make the waypoint update/re-render. Since we are
checking waypoint position inside componentDidUpdate, we call onEnter
again.

I thought about adding one or a few defers here and there to fix this
problem (setTimeout(this._handleScroll)), but I ran into a few problems
with getting all specs to pass. Also, I'm a little bit afraid to break
some implementations that rely on not being deferred. So I took the easy
way out and just moved the remembering of previous position higher up so
that the second call would correctly notice the unchanged of position.

Thanks to @imouto1994 for providing enough context so that I could
create a repro test case. Also thanks to @chengyin who reported a
similar issue (#28) and provided enough details there too. But at that
time I wasn't able to create a repro case.