### PR TITLE
Expose 'above' and 'below' as statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## master (unreleased)
 
+- Add statics for edge argument used by `onEnter` and `onLeave`
+
 ## 1.1.0
 
 - Add second parameter to `onEnter` and `onLeave` callbacks to indicate
-  from which direction the waypoint entered _from_ and _to_ respectively.
+  from which direction the waypoint entered _from_ and _to_ respectively
 
 ## 1.0.6
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ var Waypoint = require('react-waypoint');
      * viewport on initial mount.
      *
      * @param {Event|null} event
-     * @param {'above'|'below'|null} from
+     * @param {Waypoint.above|Waypoint.below|null} from
      */
     onEnter: PropTypes.func,
 
@@ -73,7 +73,7 @@ var Waypoint = require('react-waypoint');
      * Function called when waypoint leaves viewport
      *
      * @param {Event|null} event
-     * @param {'above'|'below'} to
+     * @param {Waypoint.above|Waypoint.below} to
      */
     onLeave: PropTypes.func,
 

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -94,7 +94,8 @@ describe('<Waypoint>', function() {
         });
 
         it('the onLeave handler is called', () => {
-          expect(this.props.onLeave).toHaveBeenCalledWith(jasmine.any(Event), 'above');
+          expect(this.props.onLeave)
+            .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.above);
         });
 
         it('does not call the onEnter handler', () => {
@@ -143,7 +144,8 @@ describe('<Waypoint>', function() {
       });
 
       it('calls the onEnter handler', () => {
-        expect(this.props.onEnter).toHaveBeenCalledWith(jasmine.any(Event), 'below');
+        expect(this.props.onEnter)
+          .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
       });
 
       it('does not call the onLeave handler', () => {
@@ -161,11 +163,13 @@ describe('<Waypoint>', function() {
       });
 
       it('calls the onEnter handler', () => {
-        expect(this.props.onEnter).toHaveBeenCalledWith(jasmine.any(Event), 'below');
+        expect(this.props.onEnter)
+          .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
       });
 
       it('calls the onLeave handler', () => {
-        expect(this.props.onLeave).toHaveBeenCalledWith(jasmine.any(Event), 'above');
+        expect(this.props.onLeave)
+          .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.above);
       });
     });
 
@@ -194,7 +198,8 @@ describe('<Waypoint>', function() {
         });
 
         it('calls the onEnter handler', () => {
-          expect(this.props.onEnter).toHaveBeenCalledWith(jasmine.any(Event), 'below');
+          expect(this.props.onEnter)
+            .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
         });
 
         it('does not call the onLeave handler', () => {
@@ -247,7 +252,8 @@ describe('<Waypoint>', function() {
       });
 
       it('calls the onEnter handler', () => {
-        expect(this.props.onEnter).toHaveBeenCalledWith(jasmine.any(Event), 'above');
+        expect(this.props.onEnter)
+          .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.above);
       });
 
       it('does not call the onLeave handler', () => {
@@ -260,7 +266,8 @@ describe('<Waypoint>', function() {
         });
 
         it('calls the onLeave handler', () => {
-          expect(this.props.onLeave).toHaveBeenCalledWith(jasmine.any(Event), 'below');
+          expect(this.props.onLeave)
+            .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
         });
 
         it('does not call the onEnter handler again', () => {
@@ -279,11 +286,13 @@ describe('<Waypoint>', function() {
       });
 
       it('calls the onEnter handler', () => {
-        expect(this.props.onEnter).toHaveBeenCalledWith(jasmine.any(Event), 'above');
+        expect(this.props.onEnter)
+          .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.above);
       });
 
       it('calls the onLeave handler', () => {
-        expect(this.props.onLeave).toHaveBeenCalledWith(jasmine.any(Event), 'below');
+        expect(this.props.onLeave)
+          .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
       });
     });
   });
@@ -320,7 +329,8 @@ describe('<Waypoint>', function() {
       });
 
       it('fires the onEnter handler', () => {
-        expect(this.props.onEnter).toHaveBeenCalledWith(jasmine.any(Event), 'below');
+        expect(this.props.onEnter)
+          .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
       });
     });
   });

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -21,6 +21,11 @@ const Waypoint = React.createClass({
     onLeave: PropTypes.func
   },
 
+  statics: {
+    above: POSITIONS.above,
+    below: POSITIONS.below,
+  },
+
   /**
    * @return {Object}
    */


### PR DESCRIPTION
Now that these strings are being passed as arguments to `onEnter` and
`onLeave`, I think it makes sense to expose them as statics so that
others can feel more confident about using them.