### PR TITLE
Ensure component is mounted when executing scroll handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## master (unreleased)
 
 - Add statics for edge argument used by `onEnter` and `onLeave`
+- Prevent scroll handler from blowing up if the component is not mounted at the
+  time of execution
 
 ## 1.1.0
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -104,6 +104,10 @@ const Waypoint = React.createClass({
    *   called by a React lifecyle method
    */
   _handleScroll(event) {
+    if (!this.isMounted()) {
+      return;
+    }
+
     const currentPosition = this._currentPosition();
     const previousPosition = this._previousPosition || null;
 


### PR DESCRIPTION
In the Brigade app, we've seen an error occasionally happen in
production where `this === null` inside of the `_currentPosition`
function. This causes `ReactDOM.findDOMNode` to error out.

While I'm not entirely sure I understand how this could happen, my
hypothesis is that the component has become unmounted before the scroll
handler can be executed, causing a race condition. Ensuring that the
component is mounted before executing the handler should prevent this
from happening.