### PR TITLE
Calculate proper offset when <html> or <body> has a margin

### DIFF
--- a/build/npm/waypoint.js
+++ b/build/npm/waypoint.js
@@ -147,6 +147,11 @@ var Waypoint = React.createClass({
       throw new Error('The scrollable ancestor of Waypoint needs to have positioning to ' + 'properly determine position of Waypoint (e.g. `position: relative;`)');
     }
 
+    if (this.scrollableAncestor === window) {
+      var rect = node.getBoundingClientRect();
+      return rect.top + window.pageYOffset - document.documentElement.clientTop;
+    }
+
     if (node.offsetParent === this.scrollableAncestor || !node.offsetParent) {
       return node.offsetTop;
     } else {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
     "karma-webpack": "^1.7.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "webpack": "^1.5.3"
   },
   "keywords": [

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -57,6 +57,7 @@ describe('<Waypoint>', function() {
     if (div) {
       ReactDOM.unmountComponentAtNode(div);
     }
+    scrollNodeTo(window, 0);
   });
 
   describe('when the Waypoint is visible on mount', () => {
@@ -378,6 +379,65 @@ describe('<Waypoint>', function() {
       this.subject();
       scrollNodeTo(window, window.innerHeight);
       expect(this.props.onEnter.calls.count()).toBe(1);
+    });
+  });
+
+  describe('when the <body> itself has a margin', () => {
+    beforeEach(() => {
+      // document.body.style.marginTop = '0px';
+      document.body.style.marginTop = '20px';
+      document.body.style.position = 'relative';
+      // this.topSpacerHeight = 20;
+
+      // Make the spacers large enough to make the Waypoint render off-screen
+      this.bottomSpacerHeight = window.innerHeight + 1000;
+
+      // Make the normal parent non-scrollable
+      this.parentStyle = {};
+
+      this.subject();
+    });
+
+    afterEach(() => {
+      document.body.style.marginTop = '';
+      document.body.style.position = '';
+    });
+
+    it('calls the onEnter handler', () => {
+      expect(this.props.onEnter).toHaveBeenCalledWith(null, null);
+    });
+
+    it('does not call the onLeave handler', () => {
+      expect(this.props.onLeave).not.toHaveBeenCalled();
+    });
+
+    describe('when scrolling while the waypoint is visible', () => {
+      beforeEach(() => {
+        scrollNodeTo(window, 10);
+      });
+
+      it('does not call the onEnter handler again', () => {
+        expect(this.props.onEnter.calls.count()).toBe(1);
+      });
+
+      it('does not call the onLeave handler', () => {
+        expect(this.props.onLeave).not.toHaveBeenCalled();
+      });
+
+      describe('when scrolling past it', () => {
+        beforeEach(() => {
+          scrollNodeTo(window, 25);
+        });
+
+        it('the onLeave handler is called', () => {
+          expect(this.props.onLeave)
+            .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.above);
+        });
+
+        it('does not call the onEnter handler', () => {
+          expect(this.props.onEnter.calls.count()).toBe(1);
+        });
+      });
     });
   });
 });

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -149,6 +149,11 @@ const Waypoint = React.createClass({
       );
     }
 
+    if (this.scrollableAncestor === window) {
+      const rect = node.getBoundingClientRect();
+      return rect.top + window.pageYOffset - document.documentElement.clientTop;
+    }
+
     if (node.offsetParent === this.scrollableAncestor || !node.offsetParent) {
       return node.offsetTop;
     } else {


### PR DESCRIPTION
Because offsetTop doesn't take that into account. Instead I used node.getBoundingClientRect with some adjustments, based on jQuery:

https://github.com/jquery/jquery/blob/29370190605ed5ddf5d0371c6ad886a4a4b5e0f9/src/offset.js#L110

This also has the advantage that if window is the scroll container, we get the result immediately (instead of using recursion) which might be slightly faster.