### PR TITLE
Make bundled waypoint.js easier to import

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
-  "plugins": ["transform-react-jsx"],
+  "plugins": [
+    "transform-react-jsx",
+    "add-module-exports"
+  ],
   "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-cli": "^6.0.0",
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-transform-react-jsx": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "eslint": "^1.3.1",


### PR DESCRIPTION
With Babel 6, the default export behavior changed [1] so that there's no
longer a `module.exports = ...`. This causes problems down the line,
because other projects that depend on react-waypoint will need to import
it through

  const Waypoint = reauire('react-waypoint').default;

(notice the added `.default`)

Thankfully, there's a plugin that will automatically inject the
`module.exports` for us [2]. I've added and configured that plugin in
this commit.

[1]: https://phabricator.babeljs.io/T2212
[2]: https://www.npmjs.com/package/babel-plugin-add-module-exports