### PR TITLE
New prop added - fireOnRapidScroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 node_modules
 npm-debug.log
+.idea/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ var Waypoint = require('react-waypoint');
   onEnter={this._handleWaypointEnter}
   onLeave={this._handleWaypointLeave}
   threshold={0.2}
+  fireOnRapidScroll=true
 />
 ```
 
@@ -93,7 +94,13 @@ can then use a `key` prop to control when a waypoint is reused vs. re-created.
      * Threshold - a percentage of the height of the visible
      * part of the scrollable parent (e.g. 0.1)
      */
-    threshold: PropTypes.number
+    threshold: PropTypes.number,
+
+    /**
+     * FireOnRapidScroll - if the onEnter/onLeave events are to be fired
+     * on rapid scrolling
+     */
+    fireOnRapidScroll: PropTypes.bool
   },
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     },
     {
       "name": "Flarnie Marchan"
+    },
+    {
+      "name": "Akshaya Kumar Sharma",
+      "email": "akshayakrsh@gmail.com",
+      "url": "http://www.lordakshaya.com"
     }
   ],
   "license": "MIT",

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -12,13 +12,15 @@ const propTypes = {
   // scrollable ancestor (e.g. 0.1)
   threshold: PropTypes.number,
   onEnter: PropTypes.func,
-  onLeave: PropTypes.func
+  onLeave: PropTypes.func,
+  fireOnRapidScroll: PropTypes.bool
 };
 
 const defaultProps = {
   threshold: 0,
   onEnter() {},
   onLeave() {},
+  fireOnRapidScroll: true
 };
 
 /**
@@ -112,10 +114,10 @@ export default class Waypoint extends React.Component {
     }
 
     const isRapidScrollDown = previousPosition === POSITIONS.below &&
-                              currentPosition === POSITIONS.above;
+      currentPosition === POSITIONS.above;
     const isRapidScrollUp =   previousPosition === POSITIONS.above &&
-                              currentPosition === POSITIONS.below;
-    if (isRapidScrollDown || isRapidScrollUp) {
+      currentPosition === POSITIONS.below;
+    if (this.props.fireOnRapidScroll && (isRapidScrollDown || isRapidScrollUp)) {
       // If the scroll event isn't fired often enough to occur while the
       // waypoint was visible, we trigger both callbacks anyway.
       this.props.onEnter.call(this, event, previousPosition);


### PR DESCRIPTION
The new Prop is to allow the developers to disable firing of onEnter/onLeave events on rapid scrolling.