### PR TITLE
Operate with body.offsetParent == null

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -335,16 +335,6 @@ describe('<Waypoint>', function() {
     });
   });
 
-  describe('when the scrollable parent does not have positioning', () => {
-    beforeEach(() => {
-      delete this.parentStyle.position;
-    });
-
-    it('throws an error', () => {
-      expect(this.subject).toThrow();
-    });
-  });
-
   describe('when the window is the scrollable parent', () => {
     beforeEach(() => {
       // Make the normal parent non-scrollable

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -146,7 +146,8 @@ export default class Waypoint extends React.Component {
    * @return {Number}
    */
   _distanceToTopOfScrollableAncestor(node) {
-    if (this.scrollableAncestor !== window && !node.offsetParent) {
+    if (node !== window.document.body && this.scrollableAncestor !== window &&
+      !node.offsetParent) {
       throw new Error(
         'The scrollable ancestor of Waypoint needs to have positioning to ' +
         'properly determine position of Waypoint (e.g. `position: relative;`)'


### PR DESCRIPTION
I was getting issues when the Waypoint was placed in a scrollable div and I tracked it down to this exception: "The scrollable ancestor of Waypoint needs to have positioning ...", but the positioning was there. It was failing because document.body.offsetParent is always null.