### PR TITLE
scrollableParent prop type fix

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -14,7 +14,7 @@ const propTypes = {
   onEnter: PropTypes.func,
   onLeave: PropTypes.func,
   fireOnRapidScroll: PropTypes.bool,
-  scrollableParent: PropTypes.node,
+  scrollableParent: PropTypes.any,
 };
 
 const defaultProps = {


### PR DESCRIPTION
When `scrollableParent` prop is set to a DOM element, waypoint writes a warning `Warning: Failed propType: Invalid prop scrollableParent supplied to Waypoint, expected a ReactNode.` to the browser console
This is a fix for that warning according to what README says about `scrollableParent` prop type