### PR TITLE
Handle waypoint parent not being visible

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -338,20 +338,24 @@ describe('<Waypoint>', function() {
   describe('when the scrollable parent does not have positioning', () => {
     beforeEach(() => {
       delete this.parentStyle.position;
-      this.props.onEnter.calls.reset();
-      this.props.onLeave.calls.reset();
     });
 
-    it('does not call handlers to begin with', () => {
-      expect(this.subject).not.toThrow();
+    it('does not call handlers until node becomes visible', () => {
+      // initial render hidden
+      this.component = this.subject();
       expect(this.props.onEnter).not.toHaveBeenCalled();
       expect(this.props.onLeave).not.toHaveBeenCalled();
-    });
+      const node = ReactDOM.findDOMNode(this.component);
 
-    it('does call handlers when node becomes visible', () => {
-      this.parentStyle.position = 'relative';
-      expect(this.subject).not.toThrow();
+      // now show it and we should get an onEnter
+      node.style.position = 'relative';
+      scrollNodeTo(this.component, 10);
       expect(this.props.onEnter).toHaveBeenCalled();
+
+      // now hide and we should see an onLeave
+      node.style.display = 'none';
+      scrollNodeTo(this.component, 20);
+      expect(this.props.onLeave).toHaveBeenCalled();
     });
   });
 

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -338,10 +338,20 @@ describe('<Waypoint>', function() {
   describe('when the scrollable parent does not have positioning', () => {
     beforeEach(() => {
       delete this.parentStyle.position;
+      this.props.onEnter.calls.reset();
+      this.props.onLeave.calls.reset();
     });
 
-    it('throws an error', () => {
-      expect(this.subject).toThrow();
+    it('does not call handlers to begin with', () => {
+      expect(this.subject).not.toThrow();
+      expect(this.props.onEnter).not.toHaveBeenCalled();
+      expect(this.props.onLeave).not.toHaveBeenCalled();
+    });
+
+    it('does call handlers when node becomes visible', () => {
+      this.parentStyle.position = 'relative';
+      expect(this.subject).not.toThrow();
+      expect(this.props.onEnter).toHaveBeenCalled();
     });
   });
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -5,6 +5,7 @@ const POSITIONS = {
   above: 'above',
   inside: 'inside',
   below: 'below',
+  invisible: 'invisible',
 };
 
 const propTypes = {
@@ -155,10 +156,7 @@ export default class Waypoint extends React.Component {
    */
   _distanceToTopOfScrollableAncestor(node) {
     if (this.scrollableAncestor !== window && !node.offsetParent) {
-      throw new Error(
-        'The scrollable ancestor of Waypoint needs to have positioning to ' +
-        'properly determine position of Waypoint (e.g. `position: relative;`)'
-      );
+      return null;
     }
 
     if (this.scrollableAncestor === window) {
@@ -169,8 +167,8 @@ export default class Waypoint extends React.Component {
     if (node.offsetParent === this.scrollableAncestor || !node.offsetParent) {
       return node.offsetTop;
     } else {
-      return node.offsetTop +
-        this._distanceToTopOfScrollableAncestor(node.offsetParent);
+      let nextOffset = this._distanceToTopOfScrollableAncestor(node.offsetParent);
+      return nextOffset === null ? null : node.offsetTop + nextOffset;
     }
   }
 
@@ -182,6 +180,10 @@ export default class Waypoint extends React.Component {
   _currentPosition() {
     const waypointTop =
       this._distanceToTopOfScrollableAncestor(ReactDOM.findDOMNode(this));
+    if (waypointTop === null) {
+      // not visible
+      return POSITIONS.invisible;
+    }
     let contextHeight;
     let contextScrollTop;
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -167,7 +167,8 @@ export default class Waypoint extends React.Component {
     if (node.offsetParent === this.scrollableAncestor || !node.offsetParent) {
       return node.offsetTop;
     } else {
-      let nextOffset = this._distanceToTopOfScrollableAncestor(node.offsetParent);
+      const nextOffset =
+        this._distanceToTopOfScrollableAncestor(node.offsetParent);
       return nextOffset === null ? null : node.offsetTop + nextOffset;
     }
   }


### PR DESCRIPTION
This can happen for a variety of reasons, e.g. a transition animation.

Rather than throwing an exception, we set the position to the new "invisible"
position. When the component becomes visible and we notice in the next scroll
event (or forced update), and standard event handlers will fire as we notice
the change from "invisible" to whatever the new state is.