### PR TITLE
Add onPositionChange event

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ can then use a `key` prop to control when a waypoint is reused vs. re-created.
 />
 ```
 
+Alternatively, you can also use an `onPositionChange` event to just get
+notified when the waypoint's position (e.g. inside the viewport, above or
+below) has changed.
+
+```javascript
+<Waypoint
+  onPositionChange={this._handlePositionChange}
+/>
+```
+
+
 ### Example: [JSFiddle Example][jsfiddle-example]
 
 [jsfiddle-example]: http://jsfiddle.net/L4z5wcx0/7/
@@ -87,6 +98,15 @@ can then use a `key` prop to control when a waypoint is reused vs. re-created.
      * @param {Waypoint.above|Waypoint.below} to
      */
     onLeave: PropTypes.func,
+
+    /**
+     * Function called when waypoint position changes
+     *
+     * @param {Waypoint.above|Waypoint.below|Waypoint.inside} newPosition
+     * @param {Waypoint.above|Waypoint.below|Waypoint.inside} oldPosition
+     * @param {Event|null} event
+     */
+    onPositionChange: PropTypes.func,
 
     /**
      * Threshold - a percentage of the height of the visible

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -27,6 +27,7 @@ describe('<Waypoint>', function() {
     this.props = {
       onEnter: jasmine.createSpy(),
       onLeave: jasmine.createSpy(),
+      onPositionChange: jasmine.createSpy(),
       threshold: 0,
     };
 
@@ -72,6 +73,11 @@ describe('<Waypoint>', function() {
       expect(this.props.onEnter).toHaveBeenCalledWith(null, null);
     });
 
+    it('calls the onPositionChange handler', () => {
+      expect(this.props.onPositionChange).
+        toHaveBeenCalledWith(Waypoint.inside, null, null);
+    });
+
     it('does not call the onLeave handler', () => {
       expect(this.props.onLeave).not.toHaveBeenCalled();
     });
@@ -89,6 +95,10 @@ describe('<Waypoint>', function() {
         expect(this.props.onLeave).not.toHaveBeenCalled();
       });
 
+      it('does not call the onPositionChange handler again', () => {
+        expect(this.props.onPositionChange.calls.count()).toBe(1);
+      });
+
       describe('when scrolling past it', () => {
         beforeEach(() => {
           scrollNodeTo(this.scrollable, this.topSpacerHeight + 10);
@@ -101,6 +111,12 @@ describe('<Waypoint>', function() {
 
         it('does not call the onEnter handler', () => {
           expect(this.props.onEnter.calls.count()).toBe(1);
+        });
+
+        it('the onPositionChange is called', () => {
+          expect(this.props.onPositionChange).
+            toHaveBeenCalledWith(Waypoint.above, Waypoint.inside,
+              jasmine.any(Event));
         });
       });
     });
@@ -125,9 +141,17 @@ describe('<Waypoint>', function() {
       expect(this.props.onLeave).not.toHaveBeenCalled();
     });
 
+    it('does not call the onPositionChange handler on mount', () => {
+      this.subject();
+      expect(this.props.onPositionChange).
+        toHaveBeenCalledWith(Waypoint.below, null, null);
+    });
+
     describe('when scrolling down just below the threshold', () => {
       beforeEach(() => {
-        scrollNodeTo(this.subject(), 99);
+        this.component = this.subject();
+        this.props.onPositionChange.calls.reset();
+        scrollNodeTo(this.component, 99);
       });
 
       it('does not call the onEnter handler', () => {
@@ -136,6 +160,10 @@ describe('<Waypoint>', function() {
 
       it('does not call the onLeave handler', () => {
         expect(this.props.onLeave).not.toHaveBeenCalled();
+      });
+
+      it('does not call the onPositionChange handler', () => {
+        expect(this.props.onPositionChange).not.toHaveBeenCalled();
       });
     });
 
@@ -148,6 +176,13 @@ describe('<Waypoint>', function() {
         this.scrollDown();
         expect(this.props.onEnter)
           .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
+      });
+
+      it('calls the onPositionChange handler', () => {
+        this.scrollDown();
+        expect(this.props.onPositionChange)
+          .toHaveBeenCalledWith(Waypoint.inside, Waypoint.below,
+            jasmine.any(Event));
       });
 
       it('does not call the onLeave handler', () => {
@@ -164,6 +199,13 @@ describe('<Waypoint>', function() {
           this.scrollDown();
           expect(this.props.onEnter)
             .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
+        });
+
+        it('calls the onPositionChange handler', () => {
+          this.scrollDown();
+          expect(this.props.onPositionChange)
+            .toHaveBeenCalledWith(Waypoint.inside, Waypoint.below,
+              jasmine.any(Event));
         });
 
         it('does not call the onLeave handler', () => {
@@ -179,7 +221,11 @@ describe('<Waypoint>', function() {
       // though, and one after. We want to treat this as if the waypoint was
       // visible for a brief moment, and so we fire both onEnter and onLeave.
       beforeEach(() => {
-        this.scrollQuicklyPast = () => scrollNodeTo(this.subject(), 5000);
+        this.scrollQuicklyPast = () => {
+          this.component = this.subject();
+          this.props.onPositionChange.calls.reset();
+          scrollNodeTo(this.component, 5000);
+        };
       });
 
       it('calls the onEnter handler', () => {
@@ -192,6 +238,13 @@ describe('<Waypoint>', function() {
         this.scrollQuicklyPast();
         expect(this.props.onLeave)
           .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.above);
+      });
+
+      it('calls the onPositionChange handler', () => {
+        this.scrollQuicklyPast();
+        expect(this.props.onPositionChange)
+          .toHaveBeenCalledWith(Waypoint.above, Waypoint.below,
+            jasmine.any(Event));
       });
 
       describe('when `fireOnRapidScroll` is disabled', () => {
@@ -208,6 +261,13 @@ describe('<Waypoint>', function() {
           this.scrollQuicklyPast();
           expect(this.props.onLeave).not.toHaveBeenCalled();
         });
+
+        it('calls the onPositionChange handler', () => {
+          this.scrollQuicklyPast();
+          expect(this.props.onPositionChange)
+            .toHaveBeenCalledWith(Waypoint.above, Waypoint.below,
+              jasmine.any(Event));
+        });
       });
     });
 
@@ -218,7 +278,9 @@ describe('<Waypoint>', function() {
 
       describe('when scrolling down just below the threshold', () => {
         beforeEach(() => {
-          scrollNodeTo(this.subject(), 89);
+          this.component = this.subject();
+          this.props.onPositionChange.calls.reset();
+          scrollNodeTo(this.component, 89);
         });
 
         it('does not call the onEnter handler', () => {
@@ -228,11 +290,17 @@ describe('<Waypoint>', function() {
         it('does not call the onLeave handler', () => {
           expect(this.props.onLeave).not.toHaveBeenCalled();
         });
+
+        it('does not call the onPositionChange handler', () => {
+          expect(this.props.onPositionChange).not.toHaveBeenCalled();
+        });
       });
 
       describe('when scrolling down past the threshold', () => {
         beforeEach(() => {
-          scrollNodeTo(this.subject(), 90);
+          this.component = this.subject();
+          this.props.onPositionChange.calls.reset();
+          scrollNodeTo(this.component, 90);
         });
 
         it('calls the onEnter handler', () => {
@@ -242,6 +310,12 @@ describe('<Waypoint>', function() {
 
         it('does not call the onLeave handler', () => {
           expect(this.props.onLeave).not.toHaveBeenCalled();
+        });
+
+        it('calls the onPositionChange handler', () => {
+          expect(this.props.onPositionChange)
+            .toHaveBeenCalledWith(Waypoint.inside, Waypoint.below,
+              jasmine.any(Event));
         });
       });
     });
@@ -259,6 +333,7 @@ describe('<Waypoint>', function() {
       scrollNodeTo(this.scrollable, 400);
       this.props.onEnter.calls.reset();
       this.props.onLeave.calls.reset();
+      this.props.onPositionChange.calls.reset();
       scrollNodeTo(this.scrollable, 400);
     });
 
@@ -268,6 +343,10 @@ describe('<Waypoint>', function() {
 
     it('does not call the onLeave handler', () => {
       expect(this.props.onLeave).not.toHaveBeenCalled();
+    });
+
+    it('does not call the onPositionChange handler', () => {
+      expect(this.props.onPositionChange).not.toHaveBeenCalled();
     });
 
     describe('when scrolling up not past the threshold', () => {
@@ -281,6 +360,10 @@ describe('<Waypoint>', function() {
 
       it('does not call the onLeave handler', () => {
         expect(this.props.onLeave).not.toHaveBeenCalled();
+      });
+
+      it('does not call the onPositionChange handler', () => {
+        expect(this.props.onPositionChange).not.toHaveBeenCalled();
       });
     });
 
@@ -298,6 +381,13 @@ describe('<Waypoint>', function() {
         expect(this.props.onLeave).not.toHaveBeenCalled();
       });
 
+      it('calls the onPositionChange handler', () => {
+        expect(this.props.onPositionChange)
+          .toHaveBeenCalledWith(Waypoint.inside, Waypoint.above,
+            jasmine.any(Event));
+      });
+
+
       describe('when scrolling up past the waypoint', () => {
         beforeEach(() => {
           scrollNodeTo(this.scrollable, 99);
@@ -310,6 +400,12 @@ describe('<Waypoint>', function() {
 
         it('does not call the onEnter handler again', () => {
           expect(this.props.onEnter.calls.count()).toBe(1);
+        });
+
+        it('calls the onPositionChange handler', () => {
+          expect(this.props.onPositionChange)
+            .toHaveBeenCalledWith(Waypoint.below, Waypoint.inside,
+              jasmine.any(Event));
         });
       });
     });
@@ -331,6 +427,12 @@ describe('<Waypoint>', function() {
       it('calls the onLeave handler', () => {
         expect(this.props.onLeave)
           .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
+      });
+
+      it('calls the onPositionChange handler', () => {
+        expect(this.props.onPositionChange)
+          .toHaveBeenCalledWith(Waypoint.below, Waypoint.above,
+            jasmine.any(Event));
       });
     });
   });
@@ -360,6 +462,12 @@ describe('<Waypoint>', function() {
       expect(this.props.onEnter).not.toHaveBeenCalled();
     });
 
+    it('does fire the onPositionChange handler on mount', () => {
+      this.subject();
+      expect(this.props.onPositionChange)
+        .toHaveBeenCalledWith(Waypoint.below, null, null);
+    });
+
     describe('when the Waypoint is in view', () => {
       beforeEach(() => {
         this.subject();
@@ -369,6 +477,12 @@ describe('<Waypoint>', function() {
       it('fires the onEnter handler', () => {
         expect(this.props.onEnter)
           .toHaveBeenCalledWith(jasmine.any(Event), Waypoint.below);
+      });
+
+      it('fires the onPositionChange handler', () => {
+        expect(this.props.onPositionChange)
+          .toHaveBeenCalledWith(Waypoint.inside, Waypoint.below,
+            jasmine.any(Event));
       });
     });
   });
@@ -458,8 +572,14 @@ describe('<Waypoint>', function() {
       expect(this.props.onLeave).not.toHaveBeenCalled();
     });
 
+    it('calls the onPositionChange handler', () => {
+      expect(this.props.onPositionChange)
+        .toHaveBeenCalledWith(Waypoint.inside, null, null);
+    });
+
     describe('when scrolling while the waypoint is visible', () => {
       beforeEach(() => {
+        this.props.onPositionChange.calls.reset();
         scrollNodeTo(window, 10);
       });
 
@@ -469,6 +589,10 @@ describe('<Waypoint>', function() {
 
       it('does not call the onLeave handler', () => {
         expect(this.props.onLeave).not.toHaveBeenCalled();
+      });
+
+      it('does not call the onPositionChange handler', () => {
+        expect(this.props.onPositionChange).not.toHaveBeenCalled();
       });
 
       describe('when scrolling past it', () => {
@@ -483,6 +607,12 @@ describe('<Waypoint>', function() {
 
         it('does not call the onEnter handler', () => {
           expect(this.props.onEnter.calls.count()).toBe(1);
+        });
+
+        it('the onPositionChange handler is called', () => {
+          expect(this.props.onPositionChange)
+            .toHaveBeenCalledWith(Waypoint.above, Waypoint.inside,
+              jasmine.any(Event));
         });
       });
     });

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -13,6 +13,7 @@ const propTypes = {
   threshold: PropTypes.number,
   onEnter: PropTypes.func,
   onLeave: PropTypes.func,
+  onPositionChange: PropTypes.func,
   fireOnRapidScroll: PropTypes.bool,
   scrollableAncestor: PropTypes.any,
 };
@@ -21,6 +22,7 @@ const defaultProps = {
   threshold: 0,
   onEnter() {},
   onLeave() {},
+  onPositionChange() {},
   fireOnRapidScroll: true
 };
 
@@ -130,6 +132,9 @@ export default class Waypoint extends React.Component {
       return;
     }
 
+    this.props.onPositionChange.call(this, currentPosition, previousPosition,
+      event);
+
     if (currentPosition === POSITIONS.inside) {
       this.props.onEnter.call(this, event, previousPosition);
     } else if (previousPosition === POSITIONS.inside) {
@@ -222,6 +227,7 @@ export default class Waypoint extends React.Component {
 Waypoint.propTypes = propTypes;
 Waypoint.above = POSITIONS.above;
 Waypoint.below = POSITIONS.below;
+Waypoint.inside = POSITIONS.inside;
 Waypoint.getWindow = () => {
   if (typeof window !== 'undefined') {
     return window;


### PR DESCRIPTION
While I'm doing some stuff in this codebase, here's another thing that would make life a bit easier for us.

When a waypoint's position has changed, we often just want to know what the new position is. Currently we have to write both `onEnter` and `onLeave` handlers to convert this info back into a single position update, but since the Waypoint internally already has this as a single position change, it seems like this is an easy and useful thing to expose.

While the existing events pass (event, new/old position) as the params, I consciously decided not to follow the convention and passed (new position, old position, event) in that order, since the most frequent use case is just wanting to know the new position, so it's a pain to have to write handlers that take an event as the first param only to throw it away.