### PR TITLE
not working from other "page"

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -43,11 +43,13 @@ export default class Waypoint extends React.Component {
       return;
     }
 
-    this._handleScroll = this._handleScroll.bind(this);
-    this.scrollableAncestor = this._findScrollableAncestor();
-    this.scrollableAncestor.addEventListener('scroll', this._handleScroll);
-    window.addEventListener('resize', this._handleScroll);
-    this._handleScroll(null);
+    setTimeout(() => {
+      this._handleScroll = this._handleScroll.bind(this);
+      this.scrollableAncestor = this._findScrollableAncestor();
+      this.scrollableAncestor.addEventListener('scroll', this._handleScroll);
+      window.addEventListener('resize', this._handleScroll);
+      this._handleScroll(null);
+    });
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
the problem is that if we start page with waypoint then we get correct element from _findScrollableAncestor
eg. some <div> but if we come from other page and come back then we get Window element

i test it just with 
````
        this.scrollableAncestor = this._findScrollableAncestor();
        console.log('this.scrollableAncestor', this.scrollableAncestor);
````