### PR TITLE
Add displayName for easier debugging

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -250,3 +250,4 @@ Waypoint.getWindow = () => {
   }
 };
 Waypoint.defaultProps = defaultProps;
+Waypoint.displayName = 'Waypoint';


### PR DESCRIPTION
Setting `displayName` ensures that developers can search for <Waypoint> components more easily in the Chrome Developer Tools React extension.