### PR TITLE
Add babel-plugin-add-module-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react-dom": "^0.14.0 || ^15.0.0",
+    "babel-plugin-add-module-exports": "^0.1.2"
   },
   "devDependencies": {
     "babel": "^6.0.0",


### PR DESCRIPTION
It's in your .babelrc, but our project is using Babel v6, and hasn't needed it yet. 

Until I added this to *our* devDependencies, we got this error:

```
11:33:53 webpack.1 | ERROR in /Users/pacerpro/workspace/pacerpro/~/react-waypoint/build/npm/waypoint.js
11:33:53 webpack.1 | Module build failed: ReferenceError: Unknown plugin "add-module-exports" specified in "/Users/pacerpro/workspace/pacerpro/node_modules/react-waypoint/.babelrc" at 1, attempted to resolve relative to "/Users/pacerpro/workspace/pacerpro/node_modules/react-waypoint"
```