### PR TITLE
Refactor _currentPosition to use getBoundingClientRect()

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -25,9 +25,9 @@ const scrollNodeTo = function(node, scrollTop) {
 describe('<Waypoint>', function() {
   beforeEach(() => {
     this.props = {
-      onEnter: jasmine.createSpy(),
-      onLeave: jasmine.createSpy(),
-      onPositionChange: jasmine.createSpy(),
+      onEnter: jasmine.createSpy('onEnter'),
+      onLeave: jasmine.createSpy('onLeave'),
+      onPositionChange: jasmine.createSpy('onPositionChange'),
       threshold: 0,
     };
 
@@ -519,6 +519,11 @@ describe('<Waypoint>', function() {
   describe('when the scrollable parent does not have positioning', () => {
     beforeEach(() => {
       delete this.parentStyle.position;
+      this.topSpacerHeight = 200;
+
+      // The bottom spacer needs to be tall enough to force the Waypoint to exit
+      // the viewport when scrolled all the way down.
+      this.bottomSpacerHeight = 3000;
     });
 
     it('does not call handlers until node becomes visible', () => {
@@ -530,23 +535,28 @@ describe('<Waypoint>', function() {
 
       // now show it and we should get an onEnter
       node.style.position = 'relative';
-      scrollNodeTo(this.component, 10);
+      scrollNodeTo(this.component, 100);
       expect(this.props.onEnter).
         toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
-          previousPosition: Waypoint.invisible,
+          previousPosition: Waypoint.below,
           event: jasmine.any(Event),
         });
+    });
+  });
 
-      // now hide and we should see an onLeave
+  describe('when the scrollable parent is not displayed', () => {
+    it('calls the onLeave handler', () => {
+      this.component = this.subject();
+      const node = ReactDOM.findDOMNode(this.component);
       node.style.display = 'none';
-      scrollNodeTo(this.component, 20);
+      scrollNodeTo(this.component, 0);
       expect(this.props.onLeave).
-        toHaveBeenCalledWith({
-          currentPosition: Waypoint.invisible,
-          previousPosition: Waypoint.inside,
-          event: jasmine.any(Event),
-        });
+      toHaveBeenCalledWith({
+        currentPosition: Waypoint.invisible,
+        previousPosition: Waypoint.inside,
+        event: jasmine.any(Event),
+      });
     });
   });
 

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -516,35 +516,6 @@ describe('<Waypoint>', function() {
     });
   });
 
-  describe('when the scrollable parent does not have positioning', () => {
-    beforeEach(() => {
-      delete this.parentStyle.position;
-      this.topSpacerHeight = 200;
-
-      // The bottom spacer needs to be tall enough to force the Waypoint to exit
-      // the viewport when scrolled all the way down.
-      this.bottomSpacerHeight = 3000;
-    });
-
-    it('does not call handlers until node becomes visible', () => {
-      // initial render hidden
-      this.component = this.subject();
-      expect(this.props.onEnter).not.toHaveBeenCalled();
-      expect(this.props.onLeave).not.toHaveBeenCalled();
-      const node = ReactDOM.findDOMNode(this.component);
-
-      // now show it and we should get an onEnter
-      node.style.position = 'relative';
-      scrollNodeTo(this.component, 100);
-      expect(this.props.onEnter).
-        toHaveBeenCalledWith({
-          currentPosition: Waypoint.inside,
-          previousPosition: Waypoint.below,
-          event: jasmine.any(Event),
-        });
-    });
-  });
-
   describe('when the scrollable parent is not displayed', () => {
     it('calls the onLeave handler', () => {
       this.component = this.subject();

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -201,7 +201,7 @@ export default class Waypoint extends React.Component {
       return Waypoint.below;
     }
 
-    if (contextScrollTop > waypointTop + thresholdPx) {
+    if (waypointTop + thresholdPx < contextScrollTop) {
       return Waypoint.above;
     }
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -193,11 +193,11 @@ export default class Waypoint extends React.Component {
     }
 
     if (contextScrollTop <= waypointTop + thresholdPx &&
-      waypointTop - thresholdPx <= contextBottom) {
+        waypointTop - thresholdPx <= contextBottom) {
       return Waypoint.inside;
     }
 
-    if (waypointTop - thresholdPx > contextBottom) {
+    if (contextBottom < waypointTop - thresholdPx) {
       return Waypoint.below;
     }
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -168,65 +168,44 @@ export default class Waypoint extends React.Component {
   }
 
   /**
-   * @param {Object} node
-   * @return {Number}
-   */
-  _distanceToTopOfScrollableAncestor(node) {
-    if (this.scrollableAncestor !== window && !node.offsetParent) {
-      return null;
-    }
-
-    if (this.scrollableAncestor === window) {
-      const rect = node.getBoundingClientRect();
-      return rect.top + window.pageYOffset - document.documentElement.clientTop;
-    }
-
-    if (node.offsetParent === this.scrollableAncestor || !node.offsetParent) {
-      return node.offsetTop;
-    } else {
-      const nextOffset =
-        this._distanceToTopOfScrollableAncestor(node.offsetParent);
-      return nextOffset === null ? null : node.offsetTop + nextOffset;
-    }
-  }
-
-  /**
    * @return {string} The current position of the waypoint in relation to the
    *   visible portion of the scrollable parent. One of `POSITIONS.above`,
    *   `POSITIONS.below`, or `POSITIONS.inside`.
    */
   _currentPosition() {
-    const waypointTop =
-      this._distanceToTopOfScrollableAncestor(ReactDOM.findDOMNode(this));
-    if (waypointTop === null) {
-      // not visible
-      return POSITIONS.invisible;
-    }
+    const waypointTop = ReactDOM.findDOMNode(this).getBoundingClientRect().top;
     let contextHeight;
     let contextScrollTop;
-
     if (this.scrollableAncestor === window) {
       contextHeight = window.innerHeight;
-      contextScrollTop = window.pageYOffset;
+      contextScrollTop = 0;
     } else {
       contextHeight = this.scrollableAncestor.offsetHeight;
-      contextScrollTop = this.scrollableAncestor.scrollTop;
+      contextScrollTop = ReactDOM
+        .findDOMNode(this.scrollableAncestor)
+        .getBoundingClientRect().top;
     }
-
     const thresholdPx = contextHeight * this.props.threshold;
-
-    const isBelowTop = contextScrollTop <= waypointTop + thresholdPx;
-    if (!isBelowTop) {
-      return POSITIONS.above;
-    }
-
     const contextBottom = contextScrollTop + contextHeight;
-    const isAboveBottom = contextBottom >= waypointTop - thresholdPx;
-    if (!isAboveBottom) {
-      return POSITIONS.below;
+
+    if (contextHeight === 0) {
+      return Waypoint.invisible;
     }
 
-    return POSITIONS.inside;
+    if (contextScrollTop <= waypointTop + thresholdPx &&
+      waypointTop - thresholdPx <= contextBottom) {
+      return Waypoint.inside;
+    }
+
+    if (waypointTop - thresholdPx > contextBottom) {
+      return Waypoint.below;
+    }
+
+    if (contextScrollTop > waypointTop + thresholdPx) {
+      return Waypoint.above;
+    }
+
+    return Waypoint.invisible;
   }
 
   /**


### PR DESCRIPTION
This is a pretty clean refactor. Only 1 test had to be modified (that one does bother me, though. See my note, below).

Here's why we did the refactor...

We have a component, `<StickyHeadingList>`, (https://gist.github.com/kmayer/8f1ea347cf688b0bc0f866856ec9aedc) which uses the following format:

```html
<StickyHeadingList>
  <section class="sticky-section">
    <header>Sticky-ish header</header>
    <div>content</div>
    <div>content</div>
    ...
  </section>
  <section class="sticky-section">
    <header>Next sticky-ish header</header>
    <div>more content</div>
    <div>more content</div>
    ...
  </section>
</StickyHeadingList>
```

in the component, this gets mapped to:

```jsx
<div className="sticky-heading-list">
  <article ref="stickyList" className="sticky-list-wrapper" onScroll={this.handleScroll}>
    {this.props.children}
  </article>
</div>
```

with the following style sheet:

```scss
.sticky-heading-list {
  height: 100%;
  overflow: hidden;
  position: relative;

  // The main list
  & article.sticky-list-wrapper {
    height: 100%;
    overflow-x: hidden;
    overflow-y: scroll;

    // Section headers when "sticky"
    & section.sticky-section.sticky header {
      position: absolute;
      top: 0;
    }
  }
}
```

The problem is that when `<Waypoint>` calculates `_distanceToTopOfScrollableAncestor`, it uses `offsetParent`, which skips over the scrolling element `<article.sticky-list-wrapper>` in favor of `<div.sticky-heading-list>` (because it is positioned) which doesn't scroll and is 100% of the view port. So the return value is always `null`. 

By replacing the algorithm, it works independent of offsetParent, does not need to recurse up the DOM tree and eliminates a private method.

I'm concerned that the test on line 529, "does not call handlers until node becomes visible," does not actually test the right thing any more. I don't understand how deleting the parents position, then making it `relative` again makes it "visible". I admit that it's my own lack of understanding.