### PR TITLE
Replace threshold with topOffset and bottomOffset

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -29,7 +29,6 @@ describe('<Waypoint>', function() {
       onEnter: jasmine.createSpy('onEnter'),
       onLeave: jasmine.createSpy('onLeave'),
       onPositionChange: jasmine.createSpy('onPositionChange'),
-      threshold: 0,
     };
 
     this.parentStyle = {
@@ -335,58 +334,253 @@ describe('<Waypoint>', function() {
       });
     });
 
-    describe('with a non-zero threshold', () => {
-      beforeEach(() => {
-        this.props.threshold = 0.1;
+    describe('with a non-zero topOffset', () => {
+      describe('and the topOffset is passed as a percentage', () => {
+        beforeEach(() => {
+          this.props.topOffset = '-10%';
+        });
+
+        describe('when scrolling down past the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 211);
+          });
+
+          it('calls the onLeave handler', () => {
+            expect(this.props.onLeave).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.above,
+                previousPosition: Waypoint.inside,
+                event: jasmine.any(Event),
+              });
+          });
+        });
+      });
+    });
+
+    describe('with a non-zero bottomOffset', () => {
+      describe('and the bottomOffset is passed as a percentage', () => {
+        beforeEach(() => {
+          this.props.bottomOffset = '-10%';
+        });
+
+        describe('when scrolling down just below the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 89);
+          });
+
+          it('does not call the onEnter handler', () => {
+            expect(this.props.onEnter).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('when scrolling down past the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 90);
+          });
+
+          it('calls the onEnter handler', () => {
+            expect(this.props.onEnter).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('calls the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
+        });
       });
 
-      describe('when scrolling down just below the threshold', () => {
+      describe('and the bottom offset is passed as a numeric string', () => {
         beforeEach(() => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          this.props.bottomOffset = '-10';
         });
 
-        it('does not call the onEnter handler', () => {
-          expect(this.props.onEnter).not.toHaveBeenCalled();
+        describe('when scrolling down just below the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 89);
+          });
+
+          it('does not call the onEnter handler', () => {
+            expect(this.props.onEnter).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          });
         });
 
-        it('does not call the onLeave handler', () => {
-          expect(this.props.onLeave).not.toHaveBeenCalled();
-        });
+        describe('when scrolling down past the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 90);
+          });
 
-        it('does not call the onPositionChange handler', () => {
-          expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          it('calls the onEnter handler', () => {
+            expect(this.props.onEnter).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('calls the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
         });
       });
 
-      describe('when scrolling down past the threshold', () => {
+      describe('and the bottom offset is passed as a pixel string', () => {
         beforeEach(() => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          this.props.bottomOffset = '-10px';
         });
 
-        it('calls the onEnter handler', () => {
-          expect(this.props.onEnter).
-            toHaveBeenCalledWith({
-              currentPosition: Waypoint.inside,
-              previousPosition: Waypoint.below,
-              event: jasmine.any(Event),
-            });
+        describe('when scrolling down just below the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 89);
+          });
+
+          it('does not call the onEnter handler', () => {
+            expect(this.props.onEnter).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          });
         });
 
-        it('does not call the onLeave handler', () => {
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+        describe('when scrolling down past the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 90);
+          });
+
+          it('calls the onEnter handler', () => {
+            expect(this.props.onEnter).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('calls the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
+        });
+      });
+
+      describe('and the bottom offset is passed as a number', () => {
+        beforeEach(() => {
+          this.props.bottomOffset = -10;
         });
 
-        it('calls the onPositionChange handler', () => {
-          expect(this.props.onPositionChange).
-            toHaveBeenCalledWith({
-              currentPosition: Waypoint.inside,
-              previousPosition: Waypoint.below,
-              event: jasmine.any(Event),
-            });
+        describe('when scrolling down just below the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 89);
+          });
+
+          it('does not call the onEnter handler', () => {
+            expect(this.props.onEnter).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('does not call the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('when scrolling down past the bottom offset', () => {
+          beforeEach(() => {
+            this.component = this.subject();
+            this.props.onPositionChange.calls.reset();
+            scrollNodeTo(this.component, 90);
+          });
+
+          it('calls the onEnter handler', () => {
+            expect(this.props.onEnter).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
+
+          it('does not call the onLeave handler', () => {
+            expect(this.props.onLeave).not.toHaveBeenCalled();
+          });
+
+          it('calls the onPositionChange handler', () => {
+            expect(this.props.onPositionChange).
+              toHaveBeenCalledWith({
+                currentPosition: Waypoint.inside,
+                previousPosition: Waypoint.below,
+                event: jasmine.any(Event),
+              });
+          });
         });
       });
     });


### PR DESCRIPTION
This is a WIP to resolve https://github.com/brigade/react-waypoint/issues/77

It has two notable changes:

1. `threshold` has been split into `offsetTop` and `offsetBottom`
2. The new options accept strings and numbers. Strings can be of the form `"100"`, `"100px"` or `"20%"`. Actual numbers, like `20`, are assumed to be pixel values

---

I haven't added tests 'cause I figure there might be feedback on the implementation. Once the implementation is :+1:'d I'll update the tests.