### PR TITLE
Use in-publish to ensure prepublish is only run at right time

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint . --ext .js,.jsx",
     "testonly": "karma start",
     "test": "npm run lint && npm run testonly",
-    "prepublish": "npm run build-npm"
+    "prepublish": "in-publish && npm run build-npm || not-in-publish"
   },
   "author": "Brigade Engineering",
   "license": "MIT",
@@ -33,6 +33,7 @@
     "eslint": "^2.11.1",
     "eslint-config-brigade": "^2.0.3",
     "eslint-plugin-react": "^5.1.1",
+    "in-publish": "^2.0.0",
     "jasmine-core": "^2.1.3",
     "karma": "^0.13.9",
     "karma-chrome-launcher": "^0.2.0",
@@ -40,10 +41,10 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
     "karma-webpack": "^1.7.0",
+    "mkdirp": "^0.5.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "rimraf": "^2.5.2",
-    "mkdirp": "^0.5.1",
     "webpack": "^1.5.3"
   },
   "keywords": [


### PR DESCRIPTION
The `prepublish` script has a bad name, I think, 'cause most people use it for things they only want to run right before publishing to npm, yet the script also runs on `npm install`. It looks like this lib only intends for it to be run before publish (correct me if I'm wrong!), so this PR adds the [`in-publish`](https://github.com/iarna/in-publish) lib to filter how frequently the task is run.