### PR TITLE
Initial v3 branch

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,6 +28,9 @@ module.exports = function(config) {
     },
 
     webpack: {
+      resolve: {
+        extensions: ['', '.js', '.jsx']
+      },
       module: {
         loaders: [
           {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "react-waypoint",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "A React component to execute a function whenever you scroll to an element.",
-  "main": "build/npm/waypoint.js",
+  "main": "build/npm/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/brigade/react-waypoint.git"
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/brigade/react-waypoint",
   "bugs": "https://github.com/brigade/react-waypoint/issues",
   "scripts": {
-    "build-npm": "rimraf build/npm && mkdirp build/npm && babel src/waypoint.jsx --out-file build/npm/waypoint.js",
+    "build-npm": "rimraf build/npm && mkdirp build/npm && babel src/ -d build/npm/",
     "lint": "eslint . --ext .js,.jsx",
     "testonly": "karma start",
     "test": "npm run lint && npm run testonly",
@@ -27,7 +27,7 @@
     "babel-cli": "^6.0.0",
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",
-    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-react-jsx": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "eslint": "^2.11.1",
@@ -40,10 +40,10 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
     "karma-webpack": "^1.7.0",
+    "mkdirp": "^0.5.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "rimraf": "^2.5.2",
-    "mkdirp": "^0.5.1",
     "webpack": "^1.5.3"
   },
   "keywords": [

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Waypoint from '../src/waypoint.jsx';
+import Waypoint, { POSITIONS } from '..';
 
 let div;
 
@@ -88,7 +88,7 @@ describe('<Waypoint>', function() {
 
     it('calls the onEnter handler', () => {
       expect(this.props.onEnter).toHaveBeenCalledWith({
-        currentPosition: Waypoint.inside,
+        currentPosition: POSITIONS.inside,
         previousPosition: null,
         event: null
       });
@@ -97,7 +97,7 @@ describe('<Waypoint>', function() {
     it('calls the onPositionChange handler', () => {
       expect(this.props.onPositionChange).
         toHaveBeenCalledWith({
-          currentPosition: Waypoint.inside,
+          currentPosition: POSITIONS.inside,
           previousPosition: null,
           event: null
         });
@@ -132,8 +132,8 @@ describe('<Waypoint>', function() {
         it('the onLeave handler is called', () => {
           expect(this.props.onLeave).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.above,
-              previousPosition: Waypoint.inside,
+              currentPosition: POSITIONS.above,
+              previousPosition: POSITIONS.inside,
               event: jasmine.any(Event),
             });
         });
@@ -145,8 +145,8 @@ describe('<Waypoint>', function() {
         it('the onPositionChange is called', () => {
           expect(this.props.onPositionChange).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.above,
-              previousPosition: Waypoint.inside,
+              currentPosition: POSITIONS.above,
+              previousPosition: POSITIONS.inside,
               event: jasmine.any(Event),
             });
         });
@@ -177,7 +177,7 @@ describe('<Waypoint>', function() {
       this.subject();
       expect(this.props.onPositionChange).
         toHaveBeenCalledWith({
-          currentPosition: Waypoint.below,
+          currentPosition: POSITIONS.below,
           previousPosition: null,
           event: null,
         });
@@ -212,8 +212,8 @@ describe('<Waypoint>', function() {
         this.scrollDown();
         expect(this.props.onEnter).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.below,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.below,
             event: jasmine.any(Event),
           });
       });
@@ -222,8 +222,8 @@ describe('<Waypoint>', function() {
         this.scrollDown();
         expect(this.props.onPositionChange).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.below,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.below,
             event: jasmine.any(Event),
           });
       });
@@ -242,8 +242,8 @@ describe('<Waypoint>', function() {
           this.scrollDown();
           expect(this.props.onEnter).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.inside,
-              previousPosition: Waypoint.below,
+              currentPosition: POSITIONS.inside,
+              previousPosition: POSITIONS.below,
               event: jasmine.any(Event),
             });
         });
@@ -252,8 +252,8 @@ describe('<Waypoint>', function() {
           this.scrollDown();
           expect(this.props.onPositionChange).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.inside,
-              previousPosition: Waypoint.below,
+              currentPosition: POSITIONS.inside,
+              previousPosition: POSITIONS.below,
               event: jasmine.any(Event),
             });
         });
@@ -282,8 +282,8 @@ describe('<Waypoint>', function() {
         this.scrollQuicklyPast();
         expect(this.props.onEnter).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.below,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.below,
             event: jasmine.any(Event),
           });
       });
@@ -292,8 +292,8 @@ describe('<Waypoint>', function() {
         this.scrollQuicklyPast();
         expect(this.props.onLeave).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.above,
-            previousPosition: Waypoint.inside,
+            currentPosition: POSITIONS.above,
+            previousPosition: POSITIONS.inside,
             event: jasmine.any(Event),
           });
       });
@@ -302,8 +302,8 @@ describe('<Waypoint>', function() {
         this.scrollQuicklyPast();
         expect(this.props.onPositionChange).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.above,
-            previousPosition: Waypoint.below,
+            currentPosition: POSITIONS.above,
+            previousPosition: POSITIONS.below,
             event: jasmine.any(Event),
           });
       });
@@ -327,8 +327,8 @@ describe('<Waypoint>', function() {
           this.scrollQuicklyPast();
           expect(this.props.onPositionChange).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.above,
-              previousPosition: Waypoint.below,
+              currentPosition: POSITIONS.above,
+              previousPosition: POSITIONS.below,
               event: jasmine.any(Event),
             });
         });
@@ -370,8 +370,8 @@ describe('<Waypoint>', function() {
         it('calls the onEnter handler', () => {
           expect(this.props.onEnter).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.inside,
-              previousPosition: Waypoint.below,
+              currentPosition: POSITIONS.inside,
+              previousPosition: POSITIONS.below,
               event: jasmine.any(Event),
             });
         });
@@ -383,8 +383,8 @@ describe('<Waypoint>', function() {
         it('calls the onPositionChange handler', () => {
           expect(this.props.onPositionChange).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.inside,
-              previousPosition: Waypoint.below,
+              currentPosition: POSITIONS.inside,
+              previousPosition: POSITIONS.below,
               event: jasmine.any(Event),
             });
         });
@@ -446,8 +446,8 @@ describe('<Waypoint>', function() {
       it('calls the onEnter handler', () => {
         expect(this.props.onEnter).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.above,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.above,
             event: jasmine.any(Event),
           });
       });
@@ -459,8 +459,8 @@ describe('<Waypoint>', function() {
       it('calls the onPositionChange handler', () => {
         expect(this.props.onPositionChange).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.above,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.above,
             event: jasmine.any(Event),
           });
       });
@@ -474,8 +474,8 @@ describe('<Waypoint>', function() {
         it('calls the onLeave handler', () => {
           expect(this.props.onLeave).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.below,
-              previousPosition: Waypoint.inside,
+              currentPosition: POSITIONS.below,
+              previousPosition: POSITIONS.inside,
               event: jasmine.any(Event),
             });
         });
@@ -487,8 +487,8 @@ describe('<Waypoint>', function() {
         it('calls the onPositionChange handler', () => {
           expect(this.props.onPositionChange).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.below,
-              previousPosition: Waypoint.inside,
+              currentPosition: POSITIONS.below,
+              previousPosition: POSITIONS.inside,
               event: jasmine.any(Event),
             });
         });
@@ -507,8 +507,8 @@ describe('<Waypoint>', function() {
       it('calls the onEnter handler', () => {
         expect(this.props.onEnter).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.above,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.above,
             event: jasmine.any(Event),
           });
       });
@@ -516,8 +516,8 @@ describe('<Waypoint>', function() {
       it('calls the onLeave handler', () => {
         expect(this.props.onLeave).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.below,
-            previousPosition: Waypoint.inside,
+            currentPosition: POSITIONS.below,
+            previousPosition: POSITIONS.inside,
             event: jasmine.any(Event),
           });
       });
@@ -525,8 +525,8 @@ describe('<Waypoint>', function() {
       it('calls the onPositionChange handler', () => {
         expect(this.props.onPositionChange).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.below,
-            previousPosition: Waypoint.above,
+            currentPosition: POSITIONS.below,
+            previousPosition: POSITIONS.above,
             event: jasmine.any(Event),
           });
       });
@@ -541,8 +541,8 @@ describe('<Waypoint>', function() {
       scrollNodeTo(this.component, 0);
       expect(this.props.onLeave).
       toHaveBeenCalledWith({
-        currentPosition: Waypoint.invisible,
-        previousPosition: Waypoint.inside,
+        currentPosition: POSITIONS.invisible,
+        previousPosition: POSITIONS.inside,
         event: jasmine.any(Event),
       });
     });
@@ -567,7 +567,7 @@ describe('<Waypoint>', function() {
       this.subject();
       expect(this.props.onPositionChange).
         toHaveBeenCalledWith({
-          currentPosition: Waypoint.below,
+          currentPosition: POSITIONS.below,
           previousPosition: null,
           event: null,
         });
@@ -582,8 +582,8 @@ describe('<Waypoint>', function() {
       it('fires the onEnter handler', () => {
         expect(this.props.onEnter).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.below,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.below,
             event: jasmine.any(Event),
           });
       });
@@ -591,8 +591,8 @@ describe('<Waypoint>', function() {
       it('fires the onPositionChange handler', () => {
         expect(this.props.onPositionChange).
           toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.below,
+            currentPosition: POSITIONS.inside,
+            previousPosition: POSITIONS.below,
             event: jasmine.any(Event),
           });
       });
@@ -679,7 +679,7 @@ describe('<Waypoint>', function() {
     it('calls the onEnter handler', () => {
       expect(this.props.onEnter).
         toHaveBeenCalledWith({
-          currentPosition: Waypoint.inside,
+          currentPosition: POSITIONS.inside,
           previousPosition: null,
           event: null,
         });
@@ -692,7 +692,7 @@ describe('<Waypoint>', function() {
     it('calls the onPositionChange handler', () => {
       expect(this.props.onPositionChange).
         toHaveBeenCalledWith({
-          currentPosition: Waypoint.inside,
+          currentPosition: POSITIONS.inside,
           previousPosition: null,
           event: null,
         });
@@ -724,8 +724,8 @@ describe('<Waypoint>', function() {
         it('the onLeave handler is called', () => {
           expect(this.props.onLeave).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.above,
-              previousPosition: Waypoint.inside,
+              currentPosition: POSITIONS.above,
+              previousPosition: POSITIONS.inside,
               event: jasmine.any(Event),
             });
         });
@@ -737,22 +737,12 @@ describe('<Waypoint>', function() {
         it('the onPositionChange handler is called', () => {
           expect(this.props.onPositionChange).
             toHaveBeenCalledWith({
-              currentPosition: Waypoint.above,
-              previousPosition: Waypoint.inside,
+              currentPosition: POSITIONS.above,
+              previousPosition: POSITIONS.inside,
               event: jasmine.any(Event),
             });
         });
       });
-    });
-  });
-
-  describe('when using the legacy `scrollableParent` prop', () => {
-    beforeEach(() => {
-      this.props.scrollableParent = window;
-    });
-
-    it('throws a helpful error', () => {
-      expect(this.subject).toThrowError(/changed name to `scrollableAncestor`/);
     });
   });
 

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Waypoint, { POSITIONS } from '..';
+import Waypoint, { POSITIONS } from '../src/index';
 
 let div;
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,4 @@
+import Waypoint from './waypoint';
+export default Waypoint;
+
+export { waypoint, POSITIONS, getWindow } from './waypoint-hoc';

--- a/src/waypoint-hoc.jsx
+++ b/src/waypoint-hoc.jsx
@@ -1,0 +1,225 @@
+import React, { PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+
+export const POSITIONS = {
+  above: 'above',
+  inside: 'inside',
+  below: 'below',
+  invisible: 'invisible',
+};
+
+export function getWindow() {
+  return typeof window !== 'undefined';
+}
+
+const propTypes = {
+  debug: PropTypes.bool,
+  // threshold is percentage of the height of the visible part of the
+  // scrollable ancestor (e.g. 0.1)
+  threshold: PropTypes.number,
+  scrollableAncestor: PropTypes.any,
+  throttleHandler: PropTypes.func
+};
+
+const defaultProps = {
+  threshold: 0,
+  throttleHandler(handler) {
+    return handler;
+  }
+};
+
+function debugLog() {
+  console.log(arguments); // eslint-disable-line no-console
+}
+
+/**
+ * @param {function} Component
+ * Calls a function when you scroll to the element.
+ * @return {function}
+ */
+export function waypoint(Component) {
+  class _waypoint extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        scrolled: null,
+        scrollableAncestor: null
+      };
+    }
+
+    componentDidMount() {
+      if (!getWindow()) {
+        return;
+      }
+
+      this._handleScroll =
+        this.props.throttleHandler(this._handleScroll.bind(this));
+      this.scrollableAncestor = this.state.scrollableAncestor =
+        this._findScrollableAncestor();
+      if (this.props.debug) {
+        debugLog('scrollableAncestor', this.scrollableAncestor);
+      }
+      this.scrollableAncestor.addEventListener('scroll', this._handleScroll);
+      window.addEventListener('resize', this._handleScroll);
+      this._handleScroll(null);
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+      if (!getWindow()) {
+        return;
+      }
+
+      if (prevState.scrolled === this.state.scrolled) {
+        // The element may have moved.
+        this._handleScroll(null);
+      }
+    }
+
+    componentWillUnmount() {
+      if (!getWindow()) {
+        return;
+      }
+
+      if (this.scrollableAncestor) {
+        // At the time of unmounting, the scrollable ancestor might no longer
+        // exist. Guarding against this prevents the following error:
+        //
+        //   Cannot read property 'removeEventListener' of undefined
+        this.scrollableAncestor
+          .removeEventListener('scroll', this._handleScroll);
+      }
+      window.removeEventListener('resize', this._handleScroll);
+    }
+
+    /**
+     * Traverses up the DOM to find an ancestor container which has an overflow
+     * style that allows for scrolling.
+     *
+     * @return {Object} the closest ancestor element with an overflow style that
+     *   allows for scrolling. If none is found, the `window` object is returned
+     *   as a fallback.
+     */
+    _findScrollableAncestor() {
+      if (this.props.scrollableAncestor) {
+        return this.props.scrollableAncestor;
+      }
+
+      let node = ReactDOM.findDOMNode(this);
+
+      while (node.parentNode) {
+        node = node.parentNode;
+
+        if (node === document) {
+          // This particular node does not have a computed style.
+          continue;
+        }
+
+        if (node === document.documentElement) {
+          // This particular node does not have a scroll bar,
+          // it uses the window.
+          continue;
+        }
+
+        const style = window.getComputedStyle(node);
+        const overflowY = style.getPropertyValue('overflow-y') ||
+          style.getPropertyValue('overflow');
+
+        if (overflowY === 'auto' || overflowY === 'scroll') {
+          return node;
+        }
+      }
+
+      // A scrollable ancestor element was not found,
+      // which means that we need to do stuff on window.
+      return window;
+    }
+
+    /**
+     * @param {Object} event the native scroll event coming from the scrollable
+     *   ancestor, or resize event coming from the window. Will be undefined if
+     *   called by a React lifecyle method
+     */
+    _handleScroll(event) {
+      const currentPosition = this._currentPosition();
+      const previousPosition = this._previousPosition || null;
+      if (this.props.debug) {
+        debugLog('currentPosition', currentPosition);
+        debugLog('previousPosition', previousPosition);
+      }
+
+      // Save previous position as early as possible to prevent cycles
+      this._previousPosition = currentPosition;
+
+      const scrolled = {
+        currentPosition,
+        previousPosition,
+        event,
+      };
+
+      this.setState({ scrolled });
+    }
+
+    /**
+     * @return {string} The current position of the waypoint in relation to the
+     *   visible portion of the scrollable parent. One of `POSITIONS.above`,
+     *   `POSITIONS.below`, or `POSITIONS.inside`.
+     */
+    _currentPosition() {
+      const waypointTop =
+        ReactDOM.findDOMNode(this).getBoundingClientRect().top;
+      let contextHeight;
+      let contextScrollTop;
+      if (this.scrollableAncestor === window) {
+        contextHeight = window.innerHeight;
+        contextScrollTop = 0;
+      } else {
+        contextHeight = this.scrollableAncestor.offsetHeight;
+        contextScrollTop = ReactDOM
+          .findDOMNode(this.scrollableAncestor)
+          .getBoundingClientRect().top;
+      }
+      if (this.props.debug) {
+        debugLog('waypoint top', waypointTop);
+        debugLog('scrollableAncestor height', contextHeight);
+        debugLog('scrollableAncestor scrollTop', contextScrollTop);
+      }
+      const thresholdPx = contextHeight * this.props.threshold;
+      const contextBottom = contextScrollTop + contextHeight;
+
+      if (contextHeight === 0) {
+        return POSITIONS.invisible;
+      }
+
+      if (contextScrollTop <= waypointTop + thresholdPx &&
+          waypointTop - thresholdPx <= contextBottom) {
+        return POSITIONS.inside;
+      }
+
+      if (contextBottom < waypointTop - thresholdPx) {
+        return POSITIONS.below;
+      }
+
+      if (waypointTop + thresholdPx < contextScrollTop) {
+        return POSITIONS.above;
+      }
+
+      return POSITIONS.invisible;
+    }
+
+    /**
+     * @return {Object}
+     */
+    render() {
+      return (<Component
+        {...this.props}
+        _scrolled={this.state.scrolled}
+        _scrollableAncestor={this.state.scrollableAncestor}
+      />);
+    }
+  }
+  _waypoint.propTypes = propTypes;
+  _waypoint.defaultProps = defaultProps;
+  _waypoint.displayName = '_waypoint';
+
+  return _waypoint;
+}

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -1,148 +1,54 @@
 import React, { PropTypes } from 'react';
-import ReactDOM from 'react-dom';
-
-const POSITIONS = {
-  above: 'above',
-  inside: 'inside',
-  below: 'below',
-  invisible: 'invisible',
-};
+import { waypoint, POSITIONS, getWindow } from './waypoint-hoc';
 
 const propTypes = {
-  debug: PropTypes.bool,
-  // threshold is percentage of the height of the visible part of the
-  // scrollable ancestor (e.g. 0.1)
-  threshold: PropTypes.number,
+  _scrolled: PropTypes.object,
   onEnter: PropTypes.func,
   onLeave: PropTypes.func,
   onPositionChange: PropTypes.func,
-  fireOnRapidScroll: PropTypes.bool,
-  scrollableAncestor: PropTypes.any,
-  throttleHandler: PropTypes.func
+  fireOnRapidScroll: PropTypes.bool
 };
 
 const defaultProps = {
-  threshold: 0,
   onEnter() {},
   onLeave() {},
   onPositionChange() {},
-  fireOnRapidScroll: true,
-  throttleHandler(handler) {
-    return handler;
-  }
+  fireOnRapidScroll: true
 };
-
-function debugLog() {
-  console.log(arguments); // eslint-disable-line no-console
-}
 
 /**
  * Calls a function when you scroll to the element.
  */
-export default class Waypoint extends React.Component {
-  componentWillMount() {
-    if (this.props.scrollableParent) { // eslint-disable-line react/prop-types
-      throw new Error('The `scrollableParent` prop has changed name ' +
-                      'to `scrollableAncestor`.');
-    }
-  }
-
+class Waypoint extends React.Component {
   componentDidMount() {
-    if (!Waypoint.getWindow()) {
-      return;
-    }
-    this._handleScroll =
-      this.props.throttleHandler(this._handleScroll.bind(this));
-    this.scrollableAncestor = this._findScrollableAncestor();
-    if (this.props.debug) {
-      debugLog('scrollableAncestor', this.scrollableAncestor);
-    }
-    this.scrollableAncestor.addEventListener('scroll', this._handleScroll);
-    window.addEventListener('resize', this._handleScroll);
-    this._handleScroll(null);
-  }
-
-  componentDidUpdate() {
-    if (!Waypoint.getWindow()) {
+    if (!getWindow()) {
       return;
     }
 
-    // The element may have moved.
-    this._handleScroll(null);
+    this._handleScrolled = this._handleScrolled.bind(this);
   }
 
-  componentWillUnmount() {
-    if (!Waypoint.getWindow()) {
+  shouldComponentUpdate(nextProps) {
+    this._handleScrolled(nextProps._scrolled);
+    return false;
+  }
+
+  _handleScrolled(scrolled) {
+    if (!getWindow()) {
       return;
     }
 
-    if (this.scrollableAncestor) {
-      // At the time of unmounting, the scrollable ancestor might no longer
-      // exist. Guarding against this prevents the following error:
-      //
-      //   Cannot read property 'removeEventListener' of undefined
-      this.scrollableAncestor.removeEventListener('scroll', this._handleScroll);
-    }
-    window.removeEventListener('resize', this._handleScroll);
+    // check getWindow only one time
+    this._handleScrolled = this.__handleScrolled.bind(this);
+    this._handleScrolled(scrolled);
   }
 
-  /**
-   * Traverses up the DOM to find an ancestor container which has an overflow
-   * style that allows for scrolling.
-   *
-   * @return {Object} the closest ancestor element with an overflow style that
-   *   allows for scrolling. If none is found, the `window` object is returned
-   *   as a fallback.
-   */
-  _findScrollableAncestor() {
-    if (this.props.scrollableAncestor) {
-      return this.props.scrollableAncestor;
-    }
-
-    let node = ReactDOM.findDOMNode(this);
-
-    while (node.parentNode) {
-      node = node.parentNode;
-
-      if (node === document) {
-        // This particular node does not have a computed style.
-        continue;
-      }
-
-      if (node === document.documentElement) {
-        // This particular node does not have a scroll bar, it uses the window.
-        continue;
-      }
-
-      const style = window.getComputedStyle(node);
-      const overflowY = style.getPropertyValue('overflow-y') ||
-        style.getPropertyValue('overflow');
-
-      if (overflowY === 'auto' || overflowY === 'scroll') {
-        return node;
-      }
-    }
-
-    // A scrollable ancestor element was not found, which means that we need to
-    // do stuff on window.
-    return window;
-  }
-
-  /**
-   * @param {Object} event the native scroll event coming from the scrollable
-   *   ancestor, or resize event coming from the window. Will be undefined if
-   *   called by a React lifecyle method
-   */
-  _handleScroll(event) {
-    const currentPosition = this._currentPosition();
-    const previousPosition = this._previousPosition || null;
-    if (this.props.debug) {
-      debugLog('currentPosition', currentPosition);
-      debugLog('previousPosition', previousPosition);
-    }
-
-    // Save previous position as early as possible to prevent cycles
-    this._previousPosition = currentPosition;
+  __handleScrolled(scrolled) {
+    const {
+      currentPosition,
+      previousPosition,
+      event
+    } = scrolled;
 
     if (previousPosition === currentPosition) {
       // No change since last trigger
@@ -152,8 +58,9 @@ export default class Waypoint extends React.Component {
     const callbackArg = {
       currentPosition,
       previousPosition,
-      event,
+      event
     };
+
     this.props.onPositionChange.call(this, callbackArg);
 
     if (currentPosition === POSITIONS.inside) {
@@ -164,10 +71,10 @@ export default class Waypoint extends React.Component {
 
     const isRapidScrollDown = previousPosition === POSITIONS.below &&
       currentPosition === POSITIONS.above;
-    const isRapidScrollUp =   previousPosition === POSITIONS.above &&
+    const isRapidScrollUp = previousPosition === POSITIONS.above &&
       currentPosition === POSITIONS.below;
     if (this.props.fireOnRapidScroll &&
-        (isRapidScrollDown || isRapidScrollUp)) {
+      (isRapidScrollDown || isRapidScrollUp)) {
       // If the scroll event isn't fired often enough to occur while the
       // waypoint was visible, we trigger both callbacks anyway.
       this.props.onEnter.call(this, {
@@ -183,71 +90,13 @@ export default class Waypoint extends React.Component {
     }
   }
 
-  /**
-   * @return {string} The current position of the waypoint in relation to the
-   *   visible portion of the scrollable parent. One of `POSITIONS.above`,
-   *   `POSITIONS.below`, or `POSITIONS.inside`.
-   */
-  _currentPosition() {
-    const waypointTop = ReactDOM.findDOMNode(this).getBoundingClientRect().top;
-    let contextHeight;
-    let contextScrollTop;
-    if (this.scrollableAncestor === window) {
-      contextHeight = window.innerHeight;
-      contextScrollTop = 0;
-    } else {
-      contextHeight = this.scrollableAncestor.offsetHeight;
-      contextScrollTop = ReactDOM
-        .findDOMNode(this.scrollableAncestor)
-        .getBoundingClientRect().top;
-    }
-    if (this.props.debug) {
-      debugLog('waypoint top', waypointTop);
-      debugLog('scrollableAncestor height', contextHeight);
-      debugLog('scrollableAncestor scrollTop', contextScrollTop);
-    }
-    const thresholdPx = contextHeight * this.props.threshold;
-    const contextBottom = contextScrollTop + contextHeight;
-
-    if (contextHeight === 0) {
-      return Waypoint.invisible;
-    }
-
-    if (contextScrollTop <= waypointTop + thresholdPx &&
-        waypointTop - thresholdPx <= contextBottom) {
-      return Waypoint.inside;
-    }
-
-    if (contextBottom < waypointTop - thresholdPx) {
-      return Waypoint.below;
-    }
-
-    if (waypointTop + thresholdPx < contextScrollTop) {
-      return Waypoint.above;
-    }
-
-    return Waypoint.invisible;
-  }
-
-  /**
-   * @return {Object}
-   */
   render() {
-    // We need an element that we can locate in the DOM to determine where it is
-    // rendered relative to the top of its context.
-    return <span style={{fontSize: 0}} />;
+    return <span style={{fontSize: 0}}/>;
   }
 }
 
 Waypoint.propTypes = propTypes;
-Waypoint.above = POSITIONS.above;
-Waypoint.below = POSITIONS.below;
-Waypoint.inside = POSITIONS.inside;
-Waypoint.invisible = POSITIONS.invisible;
-Waypoint.getWindow = () => {
-  if (typeof window !== 'undefined') {
-    return window;
-  }
-};
 Waypoint.defaultProps = defaultProps;
 Waypoint.displayName = 'Waypoint';
+
+export default waypoint(Waypoint);


### PR DESCRIPTION
This PR must be merged on a new development branch, `v3`, still a WIP.

In `v3` Waypoint become a use-case of a generic scroll handler higher-order React component.
New HOC `waypoint` give more freedom to developers who need more flexibility to add scroll behaviour to her own components with total freedom, relaying on robust and well tested `waypoint` scroll handler implementation.

Current code is working but TODO list must be complete before go production.

TODO
- [ ] 2 Test of 69, FAILED 
- [x] Karma autowatch isn`t working, test don´t update on src changes.
- [ ] Better jsdoc and comments
- [ ] More tests
- [ ] Better README Doc


