### PR TITLE
Passing props from constructor() to super() method

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -53,8 +53,8 @@ function debugLog() {
  * Calls a function when you scroll to the element.
  */
 export default class Waypoint extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.refElement = (e) => this._ref = e;
   }


### PR DESCRIPTION
Not passing props through super() breaks Waypoint usage in [preact](https://github.com/developit/preact).