### PR TITLE
Bail early if no ref exists

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -153,6 +153,10 @@ export default class Waypoint extends React.Component {
    *   called by a React lifecyle method
    */
   _handleScroll(event) {
+    if (!this._ref) {
+      // There's a chance we end up here after the component has been unmounted.
+      return;
+    }
     const bounds = this._getBounds();
     const currentPosition = this._currentPosition(bounds);
     const previousPosition = this._previousPosition || null;


### PR DESCRIPTION
We've seen this error come up in production:

  > Unable to get property 'getBoundingClientRect' of undefined or null
  > reference

This boils down to an assumption inside `_getBounds` that we have a
reference to the underlying DOM node (<span>). In some situations, it
looks like we don't. While I don't understand how this can happen
(afaict we clean out scroll listeners properly), returning early will at
least prevent the error from happening.

One theory I had was that the child span (which is what the ref refers
to) is unmounted before the parent. In that case, the ref will be `null`
for a short moment. But that turned out to be an incorrect theory, as
this jsfiddle shows:

  https://jsfiddle.net/69z2wepo/56241/
  (open the console log to see more info)

Apart from that, I'm currently out of theories.

Fixes #116