### PR TITLE
Avoid React warning about propTypes

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -7,32 +7,6 @@ const POSITIONS = {
   invisible: 'invisible',
 };
 
-const propTypes = {
-  debug: PropTypes.bool,
-  onEnter: PropTypes.func,
-  onLeave: PropTypes.func,
-  onPositionChange: PropTypes.func,
-  fireOnRapidScroll: PropTypes.bool,
-  scrollableAncestor: PropTypes.any,
-  throttleHandler: PropTypes.func,
-  // `topOffset` can either be a number, in which case its a distance from the
-  // top of the container in pixels, or a string value. Valid string values are
-  // of the form "20px", which is parsed as pixels, or "20%", which is parsed
-  // as a percentage of the height of the containing element.
-  // For instance, if you pass "-20%", and the containing element is 100px tall,
-  // then the waypoint will be triggered when it has been scrolled 20px beyond
-  // the top of the containing element.
-  topOffset: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
-  // `bottomOffset` is like `topOffset`, but for the bottom of the container.
-  bottomOffset: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
-};
-
 const defaultProps = {
   topOffset: '0px',
   bottomOffset: '0px',
@@ -291,8 +265,10 @@ export default class Waypoint extends React.Component {
     }
 
     const { bottomOffset, topOffset } = this.props;
-    const topOffsetPx = this._computeOffsetPixels(topOffset, contextHeight);
-    const bottomOffsetPx = this._computeOffsetPixels(bottomOffset, contextHeight);
+    const topOffsetPx = this._computeOffsetPixels(
+      topOffset, contextHeight);
+    const bottomOffsetPx = this._computeOffsetPixels(
+      bottomOffset, contextHeight);
     const contextBottom = contextScrollTop + contextHeight;
 
     return {
@@ -340,7 +316,31 @@ export default class Waypoint extends React.Component {
   }
 }
 
-Waypoint.propTypes = propTypes;
+Waypoint.propTypes = {
+  debug: PropTypes.bool,
+  onEnter: PropTypes.func,
+  onLeave: PropTypes.func,
+  onPositionChange: PropTypes.func,
+  fireOnRapidScroll: PropTypes.bool,
+  scrollableAncestor: PropTypes.any,
+  throttleHandler: PropTypes.func,
+  // `topOffset` can either be a number, in which case its a distance from the
+  // top of the container in pixels, or a string value. Valid string values are
+  // of the form "20px", which is parsed as pixels, or "20%", which is parsed
+  // as a percentage of the height of the containing element.
+  // For instance, if you pass "-20%", and the containing element is 100px tall,
+  // then the waypoint will be triggered when it has been scrolled 20px beyond
+  // the top of the containing element.
+  topOffset: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  // `bottomOffset` is like `topOffset`, but for the bottom of the container.
+  bottomOffset: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+};
 Waypoint.above = POSITIONS.above;
 Waypoint.below = POSITIONS.below;
 Waypoint.inside = POSITIONS.inside;


### PR DESCRIPTION
In the latest version of React, <Waypoint> is causing a lot of these
warnings to show up in the console log:

application.self-8f8100c….js?body=1:1512
Warning: You are manually calling a React.PropTypes validation function
for the `debug` prop on `Waypoint`. This is deprecated and will not work
in the next major version. You may be seeing this warning due to a
third-party PropTypes library. See
https://fb.me/react-warning-dont-call-proptypes for details.

I think we can avoid this by not assigning propTypes to a variable
before setting them on the React class.