### PR TITLE
Manage a single window resize event instead of one per component

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -921,7 +921,7 @@ describe('<Waypoint>', function() {
       const Wrapper = React.createClass({
         render() {
           return React.createElement('div',
-            { style: { margin: window.innerHeight * 2 + 'px 0'} },
+            { style: { margin: window.innerHeight * 2 + 'px 0' } },
             React.createElement(Waypoint, {
               onEnter: () => {
                 this.props.onEnter();

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -23,6 +23,34 @@ function debugLog() {
   console.log(arguments); // eslint-disable-line no-console
 }
 
+const resizeEventHandlers = {
+  size: 0,
+  index: 0,
+};
+
+function handleResize(event) {
+  resizeEventHandlers.forEach(handler => handler(event));
+}
+
+function addResizeEventListener(listener) {
+  if (resizeEventHandlers.size === 0) {
+    window.addEventListener('resize', handleResize);
+  }
+
+  resizeEventHandlers[resizeEventHandlers.index++] = listener;
+  resizeEventHandlers.size++;
+  return resizeEventHandlers.index;
+}
+
+function removeResizeEventListener(index) {
+  delete resizeEventHandlers[index];
+  resizeEventHandlers.size--;
+
+  if (resizeEventHandlers.size === 0) {
+    window.removeEventListener('resize', handleResize);
+  }
+}
+
 /**
  * Calls a function when you scroll to the element.
  */
@@ -51,7 +79,9 @@ export default class Waypoint extends React.Component {
       debugLog('scrollableAncestor', this.scrollableAncestor);
     }
     this.scrollableAncestor.addEventListener('scroll', this._handleScroll);
-    window.addEventListener('resize', this._handleScroll);
+
+    this.resizeEventListenerId = addResizeEventListener(this._handleScroll);
+
     this._handleScroll(null);
   }
 
@@ -76,7 +106,8 @@ export default class Waypoint extends React.Component {
       //   Cannot read property 'removeEventListener' of undefined
       this.scrollableAncestor.removeEventListener('scroll', this._handleScroll);
     }
-    window.removeEventListener('resize', this._handleScroll);
+
+    removeResizeEventListener(this.resizeEventListenerId);
   }
 
   /**

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -312,7 +312,7 @@ export default class Waypoint extends React.Component {
   render() {
     // We need an element that we can locate in the DOM to determine where it is
     // rendered relative to the top of its context.
-    return <span ref={this.refElement} style={{fontSize: 0}} />;
+    return <span ref={this.refElement} style={{ fontSize: 0 }} />;
   }
 }
 


### PR DESCRIPTION
I am looking into improving the performance of react-waypoint. We can be
a little more mindful of how many event listeners we end up creating by
only managing a single event listener. Using Chrome's timeline tool, I
have verified that this type of optimization is significant when there
are a lot of event listeners on the page.

Since we always set up a window resize event, this seemed like a good
place to start for this optimization. I chose a Set, since that seemed
like the easy and nice way to go, but it will require that older
browsers have a polyfill.

If we like this approach, I plan to do something similar for the scroll
event listeners. These are a little more complicated since they could be
attached to any scrollable container, instead of just the window. One
option would be to use a Map to manage a Set of event listeners for each
scrollable container. It might also be worth exploring using a single
top-level event listener instead of one per scrollable container, which
should be accomplishable via the Map/Set approach.

