### PR TITLE
Use as few scroll events as possible, and use passive event listeners

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -19,6 +19,34 @@ const defaultProps = {
   }
 };
 
+const CAN_USE_DOM = !!(
+  (typeof window !== 'undefined' &&
+  window.document && window.document.createElement)
+);
+
+// Adapted from Modernizr
+// https://github.com/Modernizr/Modernizr/blob/5eea7e2a/feature-detects/dom/passiveeventlisteners.js#L26-L35
+function canUsePassiveEventListener() {
+  if (!CAN_USE_DOM) {
+    return false;
+  }
+
+  let supportsPassiveOption = false;
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get() {
+        supportsPassiveOption = true;
+      }
+    });
+    window.addEventListener('test', null, opts);
+  } catch (e) {
+    // do nothing
+  }
+
+  return supportsPassiveOption;
+}
+const EVENT_OPTIONS = canUsePassiveEventListener() ? { passive: true } : undefined;
+
 function debugLog() {
   console.log(arguments); // eslint-disable-line no-console
 }
@@ -51,7 +79,11 @@ class TargetEventHandlers {
     const eventHandlers = this.getEventHandlers(eventName);
 
     if (eventHandlers.size === 0) {
-      this.target.addEventListener(eventName, this.handleEvent.bind(this, eventName));
+      this.target.addEventListener(
+        eventName,
+        this.handleEvent.bind(this, eventName),
+        EVENT_OPTIONS
+      );
     }
 
     eventHandlers.size++;
@@ -66,7 +98,11 @@ class TargetEventHandlers {
     eventHandlers.size--;
 
     if (eventHandlers.size === 0) {
-      this.target.removeEventListener(eventName, this.handleEvent.bind(this, eventName));
+      this.target.removeEventListener(
+        eventName,
+        this.handleEvent.bind(this, eventName),
+        EVENT_OPTIONS
+      );
     }
   }
 }


### PR DESCRIPTION
I originally wrote this as a simple object to handle resize event
listeners. I now want to apply the same technique to the scroll event
listeners, but since they are added to different targets, I need to make
my solution a little more generic.

I started by thinking I could use an object of objects to track the
targets and event types and to manage all of the event listeners there.
However, since we need the keys to be references to DOM nodes, that
doesn't work because different DOM nodes of the same type end up being
the same key in an object. I think Map would work here, but if the DOM
nodes are removed before removing the event listeners, we don't have a
great way of cleaning up the Map, so I think we would end up with a
memory leak. WeakMap seems pretty ideal here, but the browser support
isn't good.

So, I decided to add some data to the DOM nodes themselves. I considered
using Object.defineProperty to add a non-enumerable property to the
objects, to prevent interfering with other operations that might happen
on the node. However, since these are DOM nodes, they are unlikely to be
stringified or looped over, so I decided to go with the simpler method
instead. This is the same approach that jQuery takes [0].

[0]: https://github.com/jquery/jquery/blob/f18ca7bf/src/data/Data.js#L31-L44

---
Use passive event listeners

To maximize performance, I think it would be a good idea to use passive
event listeners by default. If there are folks who want to cancel the
scroll event, we could provide a prop to allow these to opt in to active
event listeners, but my hunch is that isn't a likely use-case for
Waypoint so I decided to not add that complexity at this time. We can
add in that prop as a minor change if it turns out it is needed.

More information:

  https://blog.chromium.org/2016/05/new-apis-to-help-developers-improve.html

Note that this is a breaking change, but I think it is unlikely to
actually break people.

Since not all browsers support passive events, and they treat the third
argument as the boolean true for `useCapture`, we need to be careful
about when we enable this option. I brought in some code from Modernizr
to do the feature detection for this. It might be nice to have a small
package that we can depend on to do this instead of copying the code in
here, but I didn't find one and I think that the small amount of code
required to do this is okay for now. This might be a good thing to
refactor out in a future iteration.

Fixes #122

