### PR TITLE
Check for handler presence before invoking it

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -71,7 +71,14 @@ class TargetEventHandlers {
   handleEvent(eventName, event) {
     const { handlers } = this.getEventHandlers(eventName);
     Object.keys(handlers).forEach(function(index) {
-      handlers[index](event);
+      const handler = handlers[index];
+      if (handler) {
+        // We need to check for presence here because a handler function may
+        // cause later handlers to get removed. This can happen if you for
+        // instance have a waypoint that unmounts another waypoint as part of an
+        // onEnter/onLeave handler.
+        handler(event);
+      }
     });
   }
 


### PR DESCRIPTION
If a waypoint unmounts another waypoint as part of handling an
onEnter/onLeave, and the two waypoints are attached to the same
scrollable ancestor, we could end up with this error:

  Uncaught TypeError: handlers[index] is not a function

Consider the following example, where the first handler removes the
second:

```js
const a = {}
a.handlers = {
  1: function() {
    delete a.handlers[2];
  },
  2: function() {},
};
Object.keys(a.handlers).forEach(function(index) {
  a.handlers[index]();
});
// => Uncaught TypeError: a.handlers[index] is not a function(…)
```

Adding a guard against undefined handlers fixes the problem. Testing
this turned out to be quite hard, so for now I'm just rolling with a
manual fix.

Fixes #126 