### PR TITLE
Avoid leaking event listeners

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -63,6 +63,7 @@ class TargetEventHandlers {
         size: 0,
         index: 0,
         handlers: {},
+        handleEvent: undefined,
       };
     }
     return this.events[eventName];
@@ -86,9 +87,11 @@ class TargetEventHandlers {
     const eventHandlers = this.getEventHandlers(eventName);
 
     if (eventHandlers.size === 0) {
+      eventHandlers.handleEvent = this.handleEvent.bind(this, eventName);
+
       this.target.addEventListener(
         eventName,
-        this.handleEvent.bind(this, eventName),
+        eventHandlers.handleEvent,
         EVENT_OPTIONS
       );
     }
@@ -107,9 +110,11 @@ class TargetEventHandlers {
     if (eventHandlers.size === 0) {
       this.target.removeEventListener(
         eventName,
-        this.handleEvent.bind(this, eventName),
+        eventHandlers.handleEvent,
         EVENT_OPTIONS
       );
+
+      eventHandlers.handleEvent = undefined;
     }
   }
 }


### PR DESCRIPTION
In c6711294 I made a change to waypoint that makes it so it sets up
fewer event listeners. Unfortunately, I did this in a way that causes
the added event listener to never be removed, as @trotzig pointed out at

  https://github.com/brigade/react-waypoint/commit/c6711294#commitcomment-19498628

This is happening because every time we call .bind() on a function, we
get a new object, which the browser is unable to use to remove the
previous function. The solution is to bind the function once, and keep
track of it so we can reuse the reference when we want to remove the
event listener.