### PR TITLE
Delay initial calling of handleScroll when mounting

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -152,7 +152,12 @@ export default class Waypoint extends React.Component {
       { passive: true }
     );
 
-    this._handleScroll(null);
+    // this._ref may occasionally not be set at this time. To help ensure that
+    // this works smoothly, we want to delay the initial execution until the
+    // next tick.
+    setTimeout(() => {
+      this._handleScroll(null);
+    }, 0);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
At Airbnb we are using react-waypoint to do some lazy image loading. We
noticed a problem on a page that has three images that are initially
rendered within the viewport and use waypoint to start the image loading
process. Sometimes one or two of the images don't start loading until
after you scroll a little, even if they are initially rendered within
the viewport.

Our hypothesis is that `this._ref` is not ready yet at the time this
function is called, which is guarded against in the handleScroll method.
We believe that by delaying the initial execution of this function, the
browser will have time to wire up the ref and our waypoints will
appropriately trigger when they are initially rendered.

We have tested this out in a development environment, and it seems to
resolve the issue for us.

cc: @nicksorrentino