### PR TITLE
Add horizontal scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ below) has changed.
     onPositionChange: PropTypes.func,
 
     /**
+     * Whether to activate on horizontal scrolling instead of vertical
+     */
+    horizontal: PropTypes.bool,
+
+    /**
      * `topOffset` can either be a number, in which case its a distance from the
      * top of the container in pixels, or a string value. Valid string values are
      * of the form "20px", which is parsed as pixels, or "20%", which is parsed
@@ -218,6 +223,15 @@ boundaries. By default, the offset is `'0px'`. If you specify a positive value,
 then the boundaries will be pushed inward, toward the center of the page. If
 you specify a negative value for an offset, then the boundary will be pushed
 outward from the center of the page.
+
+#### Horizontal Scrolling
+
+By default, waypoints listen to vertical scrolling. If you want to switch to
+horizontal scrolling instead, use the `horizontal` prop. For simplicity's sake,
+all other props and callbacks do not change. Instead, `topOffset` and
+`bottomOffset` (among other directional variables) will mean the offset from
+the left and the offset from the right, respectively, and work exactly as they
+did before, just calculated in the horizontal direction.
 
 #### Example Usage
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -11,6 +11,7 @@ const POSITIONS = {
 const defaultProps = {
   topOffset: '0px',
   bottomOffset: '0px',
+  horizontal: false,
   onEnter() {},
   onLeave() {},
   onPositionChange() {},
@@ -207,10 +208,12 @@ export default class Waypoint extends React.Component {
       }
 
       const style = window.getComputedStyle(node);
-      const overflowY = style.getPropertyValue('overflow-y') ||
-        style.getPropertyValue('overflow');
+      const overflowDirec = this.props.horizontal ?
+        style.getPropertyValue('overflow-x') :
+        style.getPropertyValue('overflow-y');
+      const overflow = overflowDirec || style.getPropertyValue('overflow');
 
-      if (overflowY === 'auto' || overflowY === 'scroll') {
+      if (overflow === 'auto' || overflow === 'scroll') {
         return node;
       }
     }
@@ -292,16 +295,21 @@ export default class Waypoint extends React.Component {
   }
 
   _getBounds() {
-    const waypointTop = this._ref.getBoundingClientRect().top;
+    const horizontal = this.props.horizontal;
+    const waypointTop = horizontal ? this._ref.getBoundingClientRect().left :
+      this._ref.getBoundingClientRect().top;
 
     let contextHeight;
     let contextScrollTop;
     if (this.scrollableAncestor === window) {
-      contextHeight = window.innerHeight;
+      contextHeight = horizontal ? window.innerWidth : window.innerHeight;
       contextScrollTop = 0;
     } else {
-      contextHeight = this.scrollableAncestor.offsetHeight;
-      contextScrollTop = this.scrollableAncestor.getBoundingClientRect().top;
+      contextHeight = horizontal ? this.scrollableAncestor.offsetWidth :
+        this.scrollableAncestor.offsetHeight;
+      contextScrollTop = horizontal ?
+        this.scrollableAncestor.getBoundingClientRect().left :
+        this.scrollableAncestor.getBoundingClientRect().top;
     }
 
     if (this.props.debug) {
@@ -340,6 +348,7 @@ Waypoint.propTypes = {
   fireOnRapidScroll: PropTypes.bool,
   scrollableAncestor: PropTypes.any,
   throttleHandler: PropTypes.func,
+  horizontal: PropTypes.bool,
 
   // `topOffset` can either be a number, in which case its a distance from the
   // top of the container in pixels, or a string value. Valid string values are


### PR DESCRIPTION
Implements #66 

To explain some of my rationale, as I was writing this I quickly realized that little of the internal logic actually needs to change to support horizontal scrolling (approx. 7 lines).
Instead of creating new `POSITIONS` and forking a bunch of functions and creating more variables (e.g. `viewportLeft`, `waypointLeft`, etc), it would actually make more sense to abstract all the code into things like `viewportEdge1`, `contextSize`, `contextScrollEdge1`, `POSITIONS.outside1`, `POSITIONS.outside2`, but as I started renaming everything, I realized that would be a major breaking API change.
Ideally, I think there should be some internal implementation like that, and then a wrapper component can just convert props like `bottomOffset` or `leftOffset` to `edge1Offset`, but for now, this is a very quick fix that adds a big, requested feature (that my organization also needs) without making any API changes. It's also the most straightforward approach to adding this, it would seem, as logic like the above creates a really confusing naming scheme while coding due to inexplicit and abstract names.


With regard to testing, I wasn't sure how to add a test for this without rewriting a lot of the test code. As this only adds a few extra lines that should be tested, I don't believe all the tests need to be redone (the logic is the same, just in a different direction), but a test to check that it's measuring horizontal distance when `horizontal` is set would be good. All the testing code specifically measures vertical distance though, so I again ran into the problem of rewriting a lot of the test code for a very small change.