### PR TITLE
Improve publishing process

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,14 @@ We love pull requests. Here's a quick guide:
 ## Publishing a new version
 
 1. Add list of changes to CHANGELOG.md. Do not commit them yet.
-2. Run `npm run version:major`, `npm run version:minor`, or `npm run
-   version:patch`.
+2. Run `npm version major`, `npm version minor`, or `npm
+   version patch`.
 
-This script will handle the rest of the process for you, including running
-tests, cleaning out the previous build, building the package, bumping the
-version, committing the changes you've made to CHANGELOG.md, tagging the
-version, pushing the changes to GitHub, pushing the tags to GitHub, and
-publishing the new version on npm.
+This will handle the rest of the process for you, including running tests,
+cleaning out the previous build, building the package, bumping the version,
+committing the changes you've made to CHANGELOG.md, tagging the version, pushing
+the changes to GitHub, pushing the tags to GitHub, and publishing the new
+version on npm.
 
 ## Code of conduct
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
     "tag": "git tag v$npm_package_version",
     "test": "npm run testonly",
     "testonly": "karma start --single-run",
-    "testonly:watch": "karma start --no-single-run",
-    "version:major": "npm --no-git-tag-version version major",
-    "version:minor": "npm --no-git-tag-version version minor",
-    "version:patch": "npm --no-git-tag-version version patch"
+    "testonly:watch": "karma start --no-single-run"
   },
   "author": "Brigade Engineering",
   "license": "MIT",


### PR DESCRIPTION
I recently added a few npm scripts to help making the release process go
smoother. Unfortunately, they caused a little bit of confusion because
some folks were still trying to use the built-in `npm version` command
instead of the new `npm run version:foo` scripts.

I poked around npm documentation a bit and discovered that we can set
things up so that `npm version` does what we want. The magic is done by
moving the command flag to avoid the automatic creation of the git tag
out of the script and into a .npmrc file.

The result of this is now `npm version major|minor|patch` will manage
the full release process for you.

To: @trotzig @ljharb