### PR TITLE
Remove support for throttleHandler prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Remove `throttleHandler`
+
 ## 4.1.0
 
 - Add `horizontal` prop. Use it to make the waypoint trigger on horizontal scrolling.

--- a/README.md
+++ b/README.md
@@ -151,13 +151,6 @@ below) has changed.
      * things down significantly, so it should only be used during development.
      */
     debug: PropTypes.bool,
-
-    /**
-     * The `throttleHandler` prop provides a function that throttle the internal
-     * scroll handler to increase performance.
-     * See the section on "Throttling" for details on how to use it.
-     */
-    throttleHandler: PropTypes.func,
   },
 ```
 
@@ -283,45 +276,6 @@ This might look something like:
 />
 ```
 
-## Throttling
-By default, waypoints will trigger on every scroll event. In most cases, this
-works just fine. But if you find yourself wanting to tweak the scrolling
-performance, the `throttleHandler` prop can come in handy. You pass in a
-function that returns a different (throttled) version of the function passed
-in. Here's an example using
-[lodash.throttle](https://www.npmjs.com/package/lodash.throttle):
-
-```jsx
-import throttle from 'lodash.throttle';
-
-<Waypoint throttleHandler={(scrollHandler) => throttle(scrollHandler, 100)} />
-```
-
-The argument passed in to the throttle handler function, `scrollHandler`, is
-waypoint's internal scroll handler. The `throttleHandler` is only invoked once
-during the lifetime of a waypoint (when the waypoint is mounted).
-
-To prevent errors coming from the fact that the scroll handler can be called
-after the waypoint is unmounted, it's a good idea to cancel the throttle
-function on unmount:
-
-```jsx
-import throttle from 'lodash.throttle';
-
-let throttledHandler;
-
-<Waypoint throttleHandler={(scrollHandler) => {
-    throttledHandler = throttle(scrollHandler, 100);
-    return throttledHandler;
-  }}
-  ref={function(component) {
-    if (!component) {
-      throttledHandler.cancel();
-    }
-  }}
-/>
-```
-
 ## Troubleshooting
 If your waypoint isn't working the way you expect it to, there are a few ways
 you can debug your setup.
@@ -343,9 +297,9 @@ but in some situations might present limitations.
 
 - We determine the scrollable-ness of a node by inspecting its computed
   overflow-y or overflow property and nothing else. This could mean that a
-  container with this style but that does not actually currently scroll will be
+  container with this style that does not actually currently scroll will be
   considered when performing visibility calculations.
-- We assume that waypoint is rendered within at most one scrollable container.
+- We assume that waypoints are rendered within at most one scrollable container.
   If you render a waypoint in multiple nested scrollable containers, the
   visibility calculations will likely not be accurate.
 - We also base the visibility calculations on the scroll position of the

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-plugin-transform-react-jsx": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "eslint": "^3.8.1",
-    "eslint-config-brigade": "^3.1.0",
+    "eslint-config-brigade": "3.1.0",
     "eslint-plugin-react": "^6.4.1",
     "in-publish": "^2.0.0",
     "jasmine-core": "^2.1.3",

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -1194,26 +1194,6 @@ describe('<Waypoint>', function() {
       expect(this.subject).toThrowError(/changed name to `scrollableAncestor`/);
     });
   });
-
-  describe('with a throttleHandler that delays execution', () => {
-    const throttleTimeout = 5;
-
-    beforeEach(() => {
-      this.props.throttleHandler = (scrollHandler) => {
-        return () => {
-          setTimeout(scrollHandler, throttleTimeout);
-        };
-      };
-      scrollNodeTo(this.subject(), 100);
-    });
-
-    it('does not call the onEnter handler immediately', () => {
-      expect(this.props.onEnter).not.toHaveBeenCalled();
-      // wait for throttle timeout to finish
-      jasmine.clock().tick(throttleTimeout);
-      expect(this.props.onEnter).toHaveBeenCalled();
-    });
-  });
 });
 
 // smoke tests for horizontal scrolling

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -16,9 +16,6 @@ const defaultProps = {
   onLeave() {},
   onPositionChange() {},
   fireOnRapidScroll: true,
-  throttleHandler(handler) {
-    return handler;
-  }
 };
 
 function debugLog() {
@@ -132,7 +129,7 @@ export default class Waypoint extends React.Component {
       return;
     }
 
-    this._handleScroll = this.props.throttleHandler(this._handleScroll.bind(this));
+    this._handleScroll = this._handleScroll.bind(this);
     this.scrollableAncestor = this._findScrollableAncestor();
 
     if (this.props.debug) {
@@ -347,7 +344,6 @@ Waypoint.propTypes = {
   onPositionChange: PropTypes.func,
   fireOnRapidScroll: PropTypes.bool,
   scrollableAncestor: PropTypes.any,
-  throttleHandler: PropTypes.func,
   horizontal: PropTypes.bool,
 
   // `topOffset` can either be a number, in which case its a distance from the


### PR DESCRIPTION
This prop has had people confused. It was added to allow people to
better control scrolling performance in their applications. Since we
added it, we've done other changes to improve performance (3ad940e,
c67112) which has made the benefit of throttling questionable. Removing
it will reduce the complexity of the component.