### PR TITLE
add typescript types definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="react" />
 
-import {ClassicComponentClass} from 'react';
+import { ClassicComponentClass } from 'react';
 
 declare namespace ReactWaypoint {
     interface CallbackArgs {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,111 @@
+/// <reference types="react" />
+
+import {ClassicComponentClass} from 'react';
+
+declare namespace ReactWaypoint {
+    interface CallbackArgs {
+        /*
+         * The position that the waypoint has at the moment.
+         * One of Waypoint.below, Waypoint.above, Waypoint.inside, and Waypoint.invisible.
+         */
+        currentPosition: string;
+
+        /*
+         * The position that the waypoint had before.
+         * One of Waypoint.below, Waypoint.above, Waypoint.inside, and Waypoint.invisible.
+         */
+        previousPosition: string;
+
+        /*
+         * The native scroll event that triggered the callback.
+         * May be missing if the callback wasn't triggered as the result of a scroll
+         */
+        event?: Event;
+
+        /*
+         * The waypoint's distance to the top of the viewport.
+         */
+        waypointTop: number;
+
+        /*
+         * The distance from the scrollable ancestor to the viewport top.
+         */
+        viewportTop: number;
+
+        /*
+         * The distance from the bottom of the scrollable ancestor to the viewport top.
+         */
+        viewportBottom: number;
+    }
+
+    interface WaypointProps {
+        /**
+         * Function called when waypoint enters viewport
+         * @param {CallbackArgs} args
+         */
+        onEnter?: (args: CallbackArgs) => void;
+
+        /**
+         * Function called when waypoint leaves viewport
+         * @param {CallbackArgs} args
+         */
+        onLeave?: (args: CallbackArgs) => void;
+
+        /**
+         * Function called when waypoint position changes
+         * @param {CallbackArgs} args
+         */
+        onPositionChange?: (args: CallbackArgs) => void;
+
+        /**
+         * Whether to activate on horizontal scrolling instead of vertical
+         */
+        horizontal?: boolean;
+
+        /**
+         * `topOffset` can either be a number, in which case its a distance from the
+         * top of the container in pixels, or a string value. Valid string values are
+         * of the form "20px", which is parsed as pixels, or "20%", which is parsed
+         * as a percentage of the height of the containing element.
+         * For instance, if you pass "-20%", and the containing element is 100px tall,
+         * then the waypoint will be triggered when it has been scrolled 20px beyond
+         * the top of the containing element.
+         */
+        topOffset?: string|number;
+
+        /**
+         * `bottomOffset` is like `topOffset`, but for the bottom of the container.
+         */
+        bottomOffset?: string|number;
+
+        /**
+         * A custom ancestor to determine if the target is visible in it.
+         * This is useful in cases where you do not want the immediate scrollable
+         * ancestor to be the container. For example, when your target is in a div
+         * that has overflow auto but you are detecting onEnter based on the window.
+         */
+        scrollableAncestor?: any;
+
+        /**
+         * If the onEnter/onLeave events are to be fired on rapid scrolling.
+         * This has no effect on onPositionChange -- it will fire anyway.
+         */
+        fireOnRapidScroll?: boolean;
+
+        /**
+         * Use this prop to get debug information in the console log. This slows
+         * things down significantly, so it should only be used during development.
+         */
+        debug?: boolean;
+    }
+
+     interface Waypoint extends ClassicComponentClass<WaypointProps> {
+         above: string;
+         below: string;
+         inside: string;
+         invisible: string;
+     }
+}
+
+declare let Waypoint: ReactWaypoint.Waypoint;
+export = Waypoint;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.0",
   "description": "A React component to execute a function whenever you scroll to an element.",
   "main": "build/waypoint.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/brigade/react-waypoint.git"
@@ -30,6 +31,7 @@
     "react": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
+    "@types/react": "^0.14.55",
     "babel": "^6.0.0",
     "babel-cli": "^6.0.0",
     "babel-core": "^6.0.0",


### PR DESCRIPTION
Hi there, this pull request adds the typescript 2 type definitions to your module.
I used your documentation to create the file and followed [those guidelines](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).

I'm just wondering about wether or not have a dependency on @types/react.

Let me know if you need anything fixed :smile_cat: 