### PR TITLE
Update type definition to support ES6 default imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,4 +108,4 @@ declare namespace ReactWaypoint {
 }
 
 declare let Waypoint: ReactWaypoint.Waypoint;
-export = Waypoint;
+export default Waypoint;


### PR DESCRIPTION
@nicolas-schmitt, this type definition assumes the module is a CommonJS/AMD module rather than an ES6 one, which forces us to import the module like so if we're using TypeScript:

`import Waypoint = require('react-waypoint')`

But react-waypoint seems like it's an ES6 module with a default export, so in theory, this should work:

`import Waypoint from 'react-waypoint'`

However, the type definition would need to indicate this. By adding a `default` attribute to the type definition, this would allow both styles of imports to work.