### PR TITLE
Reverts #147

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,4 +108,4 @@ declare namespace ReactWaypoint {
 }
 
 declare let Waypoint: ReactWaypoint.Waypoint;
-export default Waypoint;
+export = Waypoint;


### PR DESCRIPTION
@nicolas-schmitt @trotzig, can we revert the prior PR?

I misinterpreted how the build process works. Although the react-waypoint source is written as an ES6 module, because of the add-module-exports module, Babel transforms it into a CommonJS module (and only a CommonJS module -- there is no default export value in the actual build). Therefore, it cannot be imported as a pure ES6 module (import Waypoint from 'react-waypoint' does not work -- it will be undefined), and the original ES6 source file is not included by NPM when published.

I'm not sure if there's a way to publish an NPM module with both ES6 and CommonJS variants, but since that's probably a more involved discussion than a one-line fix to the type definition, I think it makes sense to revert for now.

Apologies for the inconvenience all!