### PR TITLE
Clear timeout when unmounting

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -153,7 +153,7 @@ export default class Waypoint extends React.Component {
     // this._ref may occasionally not be set at this time. To help ensure that
     // this works smoothly, we want to delay the initial execution until the
     // next tick.
-    setTimeout(() => {
+    this.initialTimeout = setTimeout(() => {
       this._handleScroll(null);
     }, 0);
   }
@@ -174,6 +174,8 @@ export default class Waypoint extends React.Component {
 
     removeEventListener(this.scrollEventListenerHandle);
     removeEventListener(this.resizeEventListenerHandle);
+
+    clearTimeout(this.initialTimeout);
   }
 
   /**


### PR DESCRIPTION
There may be some cases where waypoint mounts and then unmounts before
this timeout has an opportunity to happen. For these cases we want to
clear the timeout when the component unmounts to avoid any possible
errors.