### PR TITLE
Accept children

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ below) has changed.
 />
 ```
 
-Waypoints can have children, allowing you to track when a section of content
-enters or leaves the viewport.
+Waypoints can take a child, allowing you to track when a section of content
+enters or leaves the viewport. For details, see [Children](#children), below.
 
 ```jsx
 <Waypoint onEnter={this._handleEnter}>
@@ -87,42 +87,6 @@ enters or leaves the viewport.
   </div>
 </Waypoint>
 ```
-
-Note that this inserts a `<div>` wrapping the children passed in.
-If this is undesirable, you can use the `noWrapper={true}` prop,
-in which case you can pass a single React Class or DOM element
-which will be rendered directly. You cannot pass a stateless component,
-text node, or array of nodes when `noWrapper={true}`.
-
-```jsx
-<Waypoint onEnter={this._handleEnter} noWrapper>
-  <section>
-    This section will be rendered without an enclosing div.
-  </section>
-</Waypoint>
-
-// INVALID:
-<Waypoint noWrapper>
-  <hr />
-  <section>
-    Oops, I cannot pass multiple children with noWrapper={true}!
-  </section>
-</Waypoint>
-
-// INVALID:
-<Waypoint noWrapper>
-  Oops, I must pass an element with noWrapper={true}!
-</Waypoint>
-
-// INVALID:
-<Waypoint noWrapper>
-  <MyStatelessComponent>
-    Oops, I cannot pass a stateless component with noWrapper={true}!
-    (this is because stateless components do not accept refs)
-  </MyStatelessComponent>
-</Waypoint>
-```
-
 
 ### Example: [JSFiddle Example][jsfiddle-example]
 
@@ -296,29 +260,34 @@ top boundary or the bottom boundary.
 
 ## Children
 
-If you don't pass children into your Waypoint, then you can think of the
+If you don't pass a child into your Waypoint, then you can think of the
 waypoint as a line across the page. Whenever that line crosses a
 [boundary](#offsets-and-boundaries), then the `onEnter` or `onLeave` callbacks
 will be called.
 
-When children are passed, the waypoint's size will be determined by the
-size of a div wrapping the contained children (or, with `noWrapper={true}`,
-the size of the child element you pass). The `onEnter` callback will be called
-when *any* part of the children is visible in the viewport. The `onLeave`
-callback will be called when *all* children have exited the viewport.
-(Note that this is measured only on a single axis; strangely positioned elements
-may not work as expected).
+If you do pass a child, it must be a single DOM Element (eg; a `<div>`)
+and *not* a Component Element (eg; `<MyComponent />`).
 
-Deciding whether to pass children or not will depend on your use case. One
-example of when passing children is useful is for a scrollspy. Imagine if you
-want to fire a waypoint when a particularly long piece of content is visible
-onscreen. When the page loads, it is conceivable that both the top and bottom of
-this piece of content could lie outside of the boundaries, because the content
-is taller than the viewport. If you didn't pass children, and instead put the
-waypoint above or below the content, then you will not receive an `onEnter`
-callback (nor any other callback from this library). Instead, passing this long
-content as a child of the Waypoint would fire the `onEnter` callback when the
-page loads.
+The `onEnter` callback will be called when *any* part of the child is visible
+in the viewport. The `onLeave` callback will be called when *all* of the child
+has exited the viewport.
+
+(Note that this is measured only on a single axis. What this means is that for a
+Waypoint within a vertically scrolling parent, it could be off of the screen
+horizontally yet still fire an onEnter event, because it is within the vertical
+boundaries).
+
+Deciding whether to pass a child or not will depend on your use case. One
+example of when passing a child is useful is for a scrollspy
+(like [Bootstrap's](https://bootstrapdocs.com/v3.3.6/docs/javascript/#scrollspy)).
+Imagine if you want to fire a waypoint when a particularly long piece of content
+is visible onscreen. When the page loads, it is conceivable that both the top
+and bottom of this piece of content could lie outside of the boundaries,
+because the content is taller than the viewport. If you didn't pass a child,
+and instead put the waypoint above or below the content, then you will not
+receive an `onEnter` callback (nor any other callback from this library).
+Instead, passing this long content as a child of the Waypoint would fire the `onEnter`
+callback when the page loads.
 
 ## Containing elements and `scrollableAncestor`
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ yarn add react-waypoint
 
 ## Usage
 
-```javascript
+```jsx
 var Waypoint = require('react-waypoint');
 ```
 
-```javascript
+```jsx
 <Waypoint
   onEnter={this._handleWaypointEnter}
   onLeave={this._handleWaypointLeave}
@@ -60,7 +60,7 @@ position. Sometimes it's useful to have a waypoint that fires `onEnter` every
 time it is updated as long as it stays visible (e.g. for infinite scroll). You
 can then use a `key` prop to control when a waypoint is reused vs. re-created.
 
-```javascript
+```jsx
 <Waypoint
   key={cursor}
   onEnter={this._loadMoreContent}
@@ -71,7 +71,7 @@ Alternatively, you can also use an `onPositionChange` event to just get
 notified when the waypoint's position (e.g. inside the viewport, above or
 below) has changed.
 
-```javascript
+```jsx
 <Waypoint
   onPositionChange={this._handlePositionChange}
 />
@@ -80,13 +80,46 @@ below) has changed.
 Waypoints can have children, allowing you to track when a section of content
 enters or leaves the viewport.
 
-```javascript
-<Waypoint
-  onPositionChange={this._handlePositionChange}
->
+```jsx
+<Waypoint onEnter={this._handleEnter}>
   <div>
     Some content here
   </div>
+</Waypoint>
+```
+
+Note that this inserts a `<div>` wrapping the children passed in.
+If this is undesirable, you can use the `noWrapper={true}` prop,
+in which case you can pass a single React Class or DOM element
+which will be rendered directly. You cannot pass a stateless component,
+text node, or array of nodes when `noWrapper={true}`.
+
+```jsx
+<Waypoint onEnter={this._handleEnter} noWrapper>
+  <section>
+    This section will be rendered without an enclosing div.
+  </section>
+</Waypoint>
+
+// INVALID:
+<Waypoint noWrapper>
+  <hr />
+  <section>
+    Oops, I cannot pass multiple children with noWrapper={true}!
+  </section>
+</Waypoint>
+
+// INVALID:
+<Waypoint noWrapper>
+  Oops, I must pass an element with noWrapper={true}!
+</Waypoint>
+
+// INVALID:
+<Waypoint noWrapper>
+  <MyStatelessComponent>
+    Oops, I cannot pass a stateless component with noWrapper={true}!
+    (this is because stateless components do not accept refs)
+  </MyStatelessComponent>
 </Waypoint>
 ```
 
@@ -97,7 +130,7 @@ enters or leaves the viewport.
 
 ## Prop types
 
-```javascript
+```jsx
   propTypes: {
 
     /**
@@ -268,10 +301,13 @@ waypoint as a line across the page. Whenever that line crosses a
 [boundary](#offsets-and-boundaries), then the `onEnter` or `onLeave` callbacks
 will be called.
 
-When children are passed, then the waypoint's size will be determined by the
-size of the contained children. The `onEnter` callback will be called when *any*
-part of the children is visible in the viewport. The `onLeave` callback will be
-called when *all* children have exited the viewport.
+When children are passed, the waypoint's size will be determined by the
+size of a div wrapping the contained children (or, with `noWrapper={true}`,
+the size of the child element you pass). The `onEnter` callback will be called
+when *any* part of the children is visible in the viewport. The `onLeave`
+callback will be called when *all* children have exited the viewport.
+(Note that this is measured only on a single axis; strangely positioned elements
+may not work as expected).
 
 Deciding whether to pass children or not will depend on your use case. One
 example of when passing children is useful is for a scrollspy. Imagine if you

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ below) has changed.
 />
 ```
 
+Waypoints can have children, allowing you to track when a section of content
+enters or leaves the viewport.
+
+```javascript
+<Waypoint
+  onPositionChange={this._handlePositionChange}
+>
+  <div>
+    Some content here
+  </div>
+</Waypoint>
+```
+
 
 ### Example: [JSFiddle Example][jsfiddle-example]
 
@@ -217,7 +230,7 @@ then the boundaries will be pushed inward, toward the center of the page. If
 you specify a negative value for an offset, then the boundary will be pushed
 outward from the center of the page.
 
-#### Horizontal Scrolling
+#### Horizontal Scrolling Offsets and Boundaries
 
 By default, waypoints listen to vertical scrolling. If you want to switch to
 horizontal scrolling instead, use the `horizontal` prop. For simplicity's sake,
@@ -248,6 +261,29 @@ the `onLeave` and `onEnter` callback will be called. By using the arguments
 passed to the callbacks, you can determine whether the waypoint has crossed the
 top boundary or the bottom boundary.
 
+## Children
+
+If you don't pass children into your Waypoint, then you can think of the
+waypoint as a line across the page. Whenever that line crosses a
+[boundary](#offsets-and-boundaries), then the `onEnter` or `onLeave` callbacks
+will be called.
+
+When children are passed, then the waypoint's size will be determined by the
+size of the contained children. The `onEnter` callback will be called when *any*
+part of the children is visible in the viewport. The `onLeave` callback will be
+called when *all* children have exited the viewport.
+
+Deciding whether to pass children or not will depend on your use case. One
+example of when passing children is useful is for a scrollspy. Imagine if you
+want to fire a waypoint when a particularly long piece of content is visible
+onscreen. When the page loads, it is conceivable that both the top and bottom of
+this piece of content could lie outside of the boundaries, because the content
+is taller than the viewport. If you didn't pass children, and instead put the
+waypoint above or below the content, then you will not receive an `onEnter`
+callback (nor any other callback from this library). Instead, passing this long
+content as a child of the Waypoint would fire the `onEnter` callback when the
+page loads.
+
 ## Containing elements and `scrollableAncestor`
 
 React Waypoint positions its [boundaries](#offsets-and-boundaries) based on the
@@ -277,6 +313,7 @@ This might look something like:
 ```
 
 ## Troubleshooting
+
 If your waypoint isn't working the way you expect it to, there are a few ways
 you can debug your setup.
 

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -100,6 +100,7 @@ describe('<Waypoint>', function() {
         previousPosition: undefined,
         event: null,
         waypointTop: this.margin + this.topSpacerHeight,
+        waypointBottom: this.margin + this.topSpacerHeight,
         viewportTop: this.margin,
         viewportBottom: this.margin + this.parentHeight,
       });
@@ -112,6 +113,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: this.margin + this.topSpacerHeight,
+          waypointBottom: this.margin + this.topSpacerHeight,
           viewportTop: this.margin,
           viewportBottom: this.margin + this.parentHeight,
         });
@@ -138,6 +140,7 @@ describe('<Waypoint>', function() {
         previousPosition: undefined,
         event: null,
         waypointTop: this.margin + this.topSpacerHeight,
+        waypointBottom: this.margin + this.topSpacerHeight,
         viewportTop: this.margin - (this.parentHeight * 2),
         viewportBottom: this.margin + this.parentHeight,
       });
@@ -150,6 +153,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: this.margin + this.topSpacerHeight,
+          waypointBottom: this.margin + this.topSpacerHeight,
           viewportTop: this.margin - (this.parentHeight * 2),
           viewportBottom: this.margin + this.parentHeight,
         });
@@ -176,6 +180,7 @@ describe('<Waypoint>', function() {
         previousPosition: undefined,
         event: null,
         waypointTop: this.margin + this.topSpacerHeight,
+        waypointBottom: this.margin + this.topSpacerHeight,
         viewportTop: this.margin,
         viewportBottom: this.margin + (this.parentHeight * 3),
       });
@@ -188,6 +193,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: this.margin + this.topSpacerHeight,
+          waypointBottom: this.margin + this.topSpacerHeight,
           viewportTop: this.margin,
           viewportBottom: this.margin + (this.parentHeight * 3),
         });
@@ -215,6 +221,7 @@ describe('<Waypoint>', function() {
         previousPosition: undefined,
         event: null,
         waypointTop: this.margin + this.topSpacerHeight,
+        waypointBottom: this.margin + this.topSpacerHeight,
         viewportTop: this.margin - (this.parentHeight * 2),
         viewportBottom: this.margin + (this.parentHeight * 3),
       });
@@ -227,6 +234,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: this.margin + this.topSpacerHeight,
+          waypointBottom: this.margin + this.topSpacerHeight,
           viewportTop: this.margin - (this.parentHeight * 2),
           viewportBottom: this.margin + (this.parentHeight * 3),
         });
@@ -275,6 +283,7 @@ describe('<Waypoint>', function() {
           previousPosition: Waypoint.inside,
           event: jasmine.any(Event),
           waypointTop: this.margin - 10,
+          waypointBottom: this.margin - 10,
           viewportTop: this.margin,
           viewportBottom: this.margin + this.parentHeight,
         });
@@ -291,6 +300,7 @@ describe('<Waypoint>', function() {
           previousPosition: Waypoint.inside,
           event: jasmine.any(Event),
           waypointTop: this.margin - 10,
+          waypointBottom: this.margin - 10,
           viewportTop: this.margin,
           viewportBottom: this.margin + this.parentHeight,
         });
@@ -324,9 +334,51 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: this.margin + this.topSpacerHeight,
+          waypointBottom: this.margin + this.topSpacerHeight,
           viewportTop: this.margin,
           viewportBottom: this.margin + this.parentHeight,
         });
+    });
+
+    describe('with children', () => {
+      beforeEach(() => {
+        this.childrenHeight = 80;
+        this.props.children = [
+          React.createElement('div', {
+            key: 1,
+            style: {
+              height: this.childrenHeight / 2,
+            }
+          }),
+          React.createElement('div', {
+            key: 2,
+            style: {
+              height: this.childrenHeight / 2,
+            }
+          }),
+        ];
+      });
+
+      describe('when scrolling down far enough', () => {
+        beforeEach(() => {
+          this.component = this.subject();
+          this.props.onPositionChange.calls.reset();
+          scrollNodeTo(this.component, 100);
+        });
+
+        it('calls the onEnter handler', () => {
+          expect(this.props.onEnter).
+            toHaveBeenCalledWith({
+              currentPosition: Waypoint.inside,
+              previousPosition: Waypoint.below,
+              event: jasmine.any(Event),
+              waypointTop: this.margin + this.topSpacerHeight - 100,
+              waypointBottom: this.margin + this.topSpacerHeight - 100 + this.childrenHeight,
+              viewportTop: this.margin,
+              viewportBottom: this.margin + this.parentHeight,
+            });
+        });
+      });
     });
 
     describe('when scrolling down just below the threshold', () => {
@@ -362,6 +414,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
             waypointTop: this.margin + this.topSpacerHeight - 100,
+            waypointBottom: this.margin + this.topSpacerHeight - 100,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -375,6 +428,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
             waypointTop: this.margin + this.topSpacerHeight - 100,
+            waypointBottom: this.margin + this.topSpacerHeight - 100,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -398,6 +452,7 @@ describe('<Waypoint>', function() {
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
               waypointTop: this.margin + this.topSpacerHeight - 100,
+              waypointBottom: this.margin + this.topSpacerHeight - 100,
               viewportTop: this.margin,
               viewportBottom: this.margin + this.parentHeight,
             });
@@ -411,6 +466,7 @@ describe('<Waypoint>', function() {
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
               waypointTop: this.margin + this.topSpacerHeight - 100,
+              waypointBottom: this.margin + this.topSpacerHeight - 100,
               viewportTop: this.margin,
               viewportBottom: this.margin + this.parentHeight,
             });
@@ -444,6 +500,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
             waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
+            waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -457,6 +514,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
             waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
+            waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -470,6 +528,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
             waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
+            waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -498,6 +557,7 @@ describe('<Waypoint>', function() {
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
               waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
+              waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
               viewportTop: this.margin,
               viewportBottom: this.margin + this.parentHeight,
             });
@@ -525,6 +585,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.inside,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 211,
+                waypointBottom: this.margin + this.topSpacerHeight - 211,
                 viewportTop: this.margin + this.parentHeight * -0.1,
                 viewportBottom: this.margin + this.parentHeight,
               });
@@ -573,6 +634,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + Math.floor(this.parentHeight * 1.1),
               });
@@ -589,6 +651,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + Math.floor(this.parentHeight * 1.1),
               });
@@ -635,6 +698,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + this.parentHeight + 10,
               });
@@ -651,6 +715,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + this.parentHeight + 10,
               });
@@ -697,6 +762,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + this.parentHeight + 10,
               });
@@ -713,6 +779,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + this.parentHeight + 10,
               });
@@ -759,6 +826,7 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + this.parentHeight + 10,
               });
@@ -775,11 +843,65 @@ describe('<Waypoint>', function() {
                 previousPosition: Waypoint.below,
                 event: jasmine.any(Event),
                 waypointTop: this.margin + this.topSpacerHeight - 90,
+                waypointBottom: this.margin + this.topSpacerHeight - 90,
                 viewportTop: this.margin,
                 viewportBottom: this.margin + this.parentHeight + 10,
               });
           });
         });
+      });
+    });
+  });
+
+  describe('when the Waypoint has children and is above the top', () => {
+    beforeEach(() => {
+      this.topSpacerHeight = 200;
+      this.bottomSpacerHeight = 200;
+      this.childrenHeight = 100;
+      this.props.children =  React.createElement('div', {
+        style: {
+          height: this.childrenHeight,
+        }
+      });
+      this.scrollable = this.subject();
+
+      // Because of how we detect when a Waypoint is scrolled past without any
+      // scroll event fired when it was visible, we need to reset callback
+      // spies.
+      scrollNodeTo(this.scrollable, 400);
+      this.props.onEnter.calls.reset();
+      this.props.onLeave.calls.reset();
+      scrollNodeTo(this.scrollable, 400);
+    });
+
+    it('does not call the onEnter handler', () => {
+      expect(this.props.onEnter).not.toHaveBeenCalled();
+    });
+
+    it('does not call the onLeave handler', () => {
+      expect(this.props.onLeave).not.toHaveBeenCalled();
+    });
+
+    describe('when scrolled back up just past the bottom', () => {
+      beforeEach(() => {
+        scrollNodeTo(this.scrollable, this.topSpacerHeight + 50);
+      });
+
+      it('calls the onEnter handler', () => {
+        expect(this.props.onEnter).
+          toHaveBeenCalledWith({
+            currentPosition: Waypoint.inside,
+            previousPosition: Waypoint.above,
+            event: jasmine.any(Event),
+            waypointTop: -40,
+            waypointBottom: -40 + this.childrenHeight,
+            viewportTop: this.margin,
+            viewportBottom: this.margin + this.parentHeight,
+          });
+      });
+
+      it('does not call the onLeave handler', () => {
+        expect(this.props.onLeave).not.toHaveBeenCalled();
       });
     });
   });
@@ -842,6 +964,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
             waypointTop: this.margin + this.topSpacerHeight - 200,
+            waypointBottom: this.margin + this.topSpacerHeight - 200,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -858,6 +981,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
             waypointTop: this.margin + this.topSpacerHeight - 200,
+            waypointBottom: this.margin + this.topSpacerHeight - 200,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -876,6 +1000,7 @@ describe('<Waypoint>', function() {
               previousPosition: Waypoint.inside,
               event: jasmine.any(Event),
               waypointTop: this.margin + this.topSpacerHeight - 99,
+              waypointBottom: this.margin + this.topSpacerHeight - 99,
               viewportTop: this.margin,
               viewportBottom: this.margin + this.parentHeight,
             });
@@ -892,6 +1017,7 @@ describe('<Waypoint>', function() {
               previousPosition: Waypoint.inside,
               event: jasmine.any(Event),
               waypointTop: this.margin + this.topSpacerHeight - 99,
+              waypointBottom: this.margin + this.topSpacerHeight - 99,
               viewportTop: this.margin,
               viewportBottom: this.margin + this.parentHeight,
             });
@@ -915,6 +1041,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
             waypointTop: this.margin + this.topSpacerHeight,
+            waypointBottom: this.margin + this.topSpacerHeight,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -927,6 +1054,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
             waypointTop: this.margin + this.topSpacerHeight,
+            waypointBottom: this.margin + this.topSpacerHeight,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -939,6 +1067,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
             waypointTop: this.margin + this.topSpacerHeight,
+            waypointBottom: this.margin + this.topSpacerHeight,
             viewportTop: this.margin,
             viewportBottom: this.margin + this.parentHeight,
           });
@@ -958,6 +1087,7 @@ describe('<Waypoint>', function() {
         previousPosition: Waypoint.inside,
         event: jasmine.any(Event),
         waypointTop: 0,
+        waypointBottom: 0,
         viewportTop: 0,
         viewportBottom: 0,
       });
@@ -988,6 +1118,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: this.margin + this.topSpacerHeight,
+          waypointBottom: this.margin + this.topSpacerHeight,
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
@@ -1006,6 +1137,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
             waypointTop: this.margin + Math.ceil(window.innerHeight / 2),
+            waypointBottom: this.margin + Math.ceil(window.innerHeight / 2),
             viewportTop: 0,
             viewportBottom: window.innerHeight,
           });
@@ -1018,6 +1150,7 @@ describe('<Waypoint>', function() {
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
             waypointTop: this.margin + Math.ceil(window.innerHeight / 2),
+            waypointBottom: this.margin + Math.ceil(window.innerHeight / 2),
             viewportTop: 0,
             viewportBottom: window.innerHeight,
           });
@@ -1110,6 +1243,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: 20 + this.topSpacerHeight,
+          waypointBottom: 20 + this.topSpacerHeight,
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
@@ -1126,6 +1260,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: 20 + this.topSpacerHeight,
+          waypointBottom: 20 + this.topSpacerHeight,
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
@@ -1161,6 +1296,7 @@ describe('<Waypoint>', function() {
               previousPosition: Waypoint.inside,
               event: jasmine.any(Event),
               waypointTop: 20 + this.topSpacerHeight - 25,
+              waypointBottom: 20 + this.topSpacerHeight - 25,
               viewportTop: 0,
               viewportBottom: window.innerHeight,
             });
@@ -1177,6 +1313,7 @@ describe('<Waypoint>', function() {
               previousPosition: Waypoint.inside,
               event: jasmine.any(Event),
               waypointTop: 20 + this.topSpacerHeight - 25,
+              waypointBottom: 20 + this.topSpacerHeight - 25,
               viewportTop: 0,
               viewportBottom: window.innerHeight,
             });
@@ -1208,7 +1345,7 @@ const scrollNodeToHorizontal = function(node, scrollLeft) {
   node.dispatchEvent(event);
 };
 
-describe('<Waypoint>', function() {
+describe('<Waypoint> Horizontal', function() {
   beforeEach(() => {
     jasmine.clock().install();
     document.body.style.margin = 'auto'; // should be no horizontal margin
@@ -1277,6 +1414,7 @@ describe('<Waypoint>', function() {
           previousPosition: undefined,
           event: null,
           waypointTop: this.margin + this.leftSpacerWidth,
+          waypointBottom: this.margin + this.leftSpacerWidth,
           viewportTop: this.margin,
           viewportBottom: this.margin + this.parentWidth,
         });

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Waypoint from '../src/waypoint.jsx';
@@ -343,7 +344,7 @@ describe('<Waypoint>', function() {
     describe('with children', () => {
       beforeEach(() => {
         this.childrenHeight = 80;
-        this.props.children = [
+        this.props.children = React.createElement('div', {}, [
           React.createElement('div', {
             key: 1,
             style: {
@@ -356,7 +357,7 @@ describe('<Waypoint>', function() {
               height: this.childrenHeight / 2,
             }
           }),
-        ];
+        ]);
       });
 
       describe('when scrolling down far enough', () => {
@@ -853,6 +854,29 @@ describe('<Waypoint>', function() {
     });
   });
 
+  describe('when the Waypoint has children that are not DOM Elements', () => {
+    const errorMessage = 'You must wrap any Component Elements passed to Waypoint ' +
+      'in a DOM Element (eg; a <div>).';
+
+    it('errors with a stateless component', () => {
+      const StatelessComponent = () => React.createElement('div');
+      this.props.children = React.createElement(StatelessComponent);
+
+      expect(this.subject).toThrowError(errorMessage);
+    });
+
+    it('errors with a class-based component', () => {
+      class ClassBasedComponent extends React.Component {
+        render() {
+          return React.createElement('div');
+        }
+      }
+      this.props.children = React.createElement(ClassBasedComponent);
+
+      expect(this.subject).toThrowError(errorMessage);
+    });
+  });
+
   describe('when the Waypoint has children and is above the top', () => {
     beforeEach(() => {
       this.topSpacerHeight = 200;
@@ -872,70 +896,6 @@ describe('<Waypoint>', function() {
       this.props.onEnter.calls.reset();
       this.props.onLeave.calls.reset();
       scrollNodeTo(this.scrollable, 400);
-    });
-
-    it('does not call the onEnter handler', () => {
-      expect(this.props.onEnter).not.toHaveBeenCalled();
-    });
-
-    it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
-    });
-
-    describe('when scrolled back up just past the bottom', () => {
-      beforeEach(() => {
-        scrollNodeTo(this.scrollable, this.topSpacerHeight + 50);
-      });
-
-      it('calls the onEnter handler', () => {
-        expect(this.props.onEnter).
-          toHaveBeenCalledWith({
-            currentPosition: Waypoint.inside,
-            previousPosition: Waypoint.above,
-            event: jasmine.any(Event),
-            waypointTop: -40,
-            waypointBottom: -40 + this.childrenHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
-          });
-      });
-
-      it('does not call the onLeave handler', () => {
-        expect(this.props.onLeave).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('when noWrapper=true and child is above the top', () => {
-    beforeEach(() => {
-      this.topSpacerHeight = 200;
-      this.bottomSpacerHeight = 200;
-      this.childrenHeight = 100;
-      this.childRefSpy = jasmine.createSpy('ref');
-      this.props.noWrapper = true;
-      this.props.children =  React.createElement('section', {
-        ref: this.childRefSpy,
-        style: {
-          height: this.childrenHeight,
-        }
-      });
-      this.scrollable = this.subject();
-
-      // Because of how we detect when a Waypoint is scrolled past without any
-      // scroll event fired when it was visible, we need to reset callback
-      // spies.
-      scrollNodeTo(this.scrollable, 400);
-      this.props.onEnter.calls.reset();
-      this.props.onLeave.calls.reset();
-      scrollNodeTo(this.scrollable, 400);
-    });
-
-    it('calls the original ref handler', () => {
-      expect(this.childRefSpy).toHaveBeenCalled();
-    });
-
-    it('does not have an extra div', () => {
-      expect(this.scrollable.children[1].nodeName).toBe('SECTION');
     });
 
     it('does not call the onEnter handler', () => {

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -906,6 +906,70 @@ describe('<Waypoint>', function() {
     });
   });
 
+  describe('when noWrapper=true and child is above the top', () => {
+    beforeEach(() => {
+      this.topSpacerHeight = 200;
+      this.bottomSpacerHeight = 200;
+      this.childrenHeight = 100;
+      this.childRefSpy = jasmine.createSpy('ref');
+      this.props.noWrapper = true;
+      this.props.children =  React.createElement('section', {
+        ref: this.childRefSpy,
+        style: {
+          height: this.childrenHeight,
+        }
+      });
+      this.scrollable = this.subject();
+
+      // Because of how we detect when a Waypoint is scrolled past without any
+      // scroll event fired when it was visible, we need to reset callback
+      // spies.
+      scrollNodeTo(this.scrollable, 400);
+      this.props.onEnter.calls.reset();
+      this.props.onLeave.calls.reset();
+      scrollNodeTo(this.scrollable, 400);
+    });
+
+    it('calls the original ref handler', () => {
+      expect(this.childRefSpy).toHaveBeenCalled();
+    });
+
+    it('does not have an extra div', () => {
+      expect(this.scrollable.children[1].nodeName).toBe('SECTION');
+    });
+
+    it('does not call the onEnter handler', () => {
+      expect(this.props.onEnter).not.toHaveBeenCalled();
+    });
+
+    it('does not call the onLeave handler', () => {
+      expect(this.props.onLeave).not.toHaveBeenCalled();
+    });
+
+    describe('when scrolled back up just past the bottom', () => {
+      beforeEach(() => {
+        scrollNodeTo(this.scrollable, this.topSpacerHeight + 50);
+      });
+
+      it('calls the onEnter handler', () => {
+        expect(this.props.onEnter).
+          toHaveBeenCalledWith({
+            currentPosition: Waypoint.inside,
+            previousPosition: Waypoint.above,
+            event: jasmine.any(Event),
+            waypointTop: -40,
+            waypointBottom: -40 + this.childrenHeight,
+            viewportTop: this.margin,
+            viewportBottom: this.margin + this.parentHeight,
+          });
+      });
+
+      it('does not call the onLeave handler', () => {
+        expect(this.props.onLeave).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('when the Waypoint is above the top', () => {
     beforeEach(() => {
       this.topSpacerHeight = 200;

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -34,8 +34,21 @@ function getCurrentPosition(bounds) {
     return POSITIONS.invisible;
   }
 
+  // top is within the screen
   if (bounds.viewportTop <= bounds.waypointTop &&
       bounds.waypointTop <= bounds.viewportBottom) {
+    return POSITIONS.inside;
+  }
+
+  // bottom is within the screen
+  if (bounds.viewportTop <= bounds.waypointBottom &&
+      bounds.waypointBottom <= bounds.viewportBottom) {
+    return POSITIONS.inside;
+  }
+
+  // top is above the screen and bottom is below the screen
+  if (bounds.waypointTop <= bounds.viewportTop &&
+      bounds.viewportBottom <= bounds.waypointBottom) {
     return POSITIONS.inside;
   }
 
@@ -255,6 +268,7 @@ export default class Waypoint extends React.Component {
       previousPosition,
       event,
       waypointTop: bounds.waypointTop,
+      waypointBottom: bounds.waypointBottom,
       viewportTop: bounds.viewportTop,
       viewportBottom: bounds.viewportBottom,
     };
@@ -279,6 +293,7 @@ export default class Waypoint extends React.Component {
         previousPosition,
         event,
         waypointTop: bounds.waypointTop,
+        waypointBottom: bounds.waypointBottom,
         viewportTop: bounds.viewportTop,
         viewportBottom: bounds.viewportBottom,
       });
@@ -287,6 +302,7 @@ export default class Waypoint extends React.Component {
         previousPosition: POSITIONS.inside,
         event,
         waypointTop: bounds.waypointTop,
+        waypointBottom: bounds.waypointBottom,
         viewportTop: bounds.viewportTop,
         viewportBottom: bounds.viewportBottom,
       });
@@ -295,8 +311,9 @@ export default class Waypoint extends React.Component {
 
   _getBounds() {
     const horizontal = this.props.horizontal;
-    const waypointTop = horizontal ? this._ref.getBoundingClientRect().left :
-      this._ref.getBoundingClientRect().top;
+    const { left, top, right, bottom } = this._ref.getBoundingClientRect();
+    const waypointTop = horizontal ? left : top;
+    const waypointBottom = horizontal ? right : bottom;
 
     let contextHeight;
     let contextScrollTop;
@@ -313,6 +330,7 @@ export default class Waypoint extends React.Component {
 
     if (this.props.debug) {
       debugLog('waypoint top', waypointTop);
+      debugLog('waypoint bottom', waypointBottom);
       debugLog('scrollableAncestor height', contextHeight);
       debugLog('scrollableAncestor scrollTop', contextScrollTop);
     }
@@ -324,6 +342,7 @@ export default class Waypoint extends React.Component {
 
     return {
       waypointTop,
+      waypointBottom,
       viewportTop: contextScrollTop + topOffsetPx,
       viewportBottom: contextBottom - bottomOffsetPx,
     };
@@ -333,6 +352,10 @@ export default class Waypoint extends React.Component {
    * @return {Object}
    */
   render() {
+    if (this.props.children) {
+      return <div ref={this.refElement}>{this.props.children}</div>;
+    }
+
     // We need an element that we can locate in the DOM to determine where it is
     // rendered relative to the top of its context.
     return <span ref={this.refElement} style={{ fontSize: 0 }} />;
@@ -340,6 +363,7 @@ export default class Waypoint extends React.Component {
 }
 
 Waypoint.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
   debug: PropTypes.bool,
   onEnter: PropTypes.func,
   onLeave: PropTypes.func,

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -34,19 +34,19 @@ function getCurrentPosition(bounds) {
     return POSITIONS.invisible;
   }
 
-  // top is within the screen
+  // top is within the viewport
   if (bounds.viewportTop <= bounds.waypointTop &&
       bounds.waypointTop <= bounds.viewportBottom) {
     return POSITIONS.inside;
   }
 
-  // bottom is within the screen
+  // bottom is within the viewport
   if (bounds.viewportTop <= bounds.waypointBottom &&
       bounds.waypointBottom <= bounds.viewportBottom) {
     return POSITIONS.inside;
   }
 
-  // top is above the screen and bottom is below the screen
+  // top is above the viewport and bottom is below the viewport
   if (bounds.waypointTop <= bounds.viewportTop &&
       bounds.viewportBottom <= bounds.waypointBottom) {
     return POSITIONS.inside;
@@ -352,6 +352,17 @@ export default class Waypoint extends React.Component {
    * @return {Object}
    */
   render() {
+    if (this.props.noWrapper) {
+      const child = React.Children.only(this.props.children);
+      const ref = (node) => {
+        this.refElement(node);
+        if (this.props.children.ref) {
+          this.props.children.ref(node);
+        }
+      };
+      return React.cloneElement(child, { ref });
+    }
+
     if (this.props.children) {
       return <div ref={this.refElement}>{this.props.children}</div>;
     }
@@ -363,7 +374,8 @@ export default class Waypoint extends React.Component {
 }
 
 Waypoint.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
+  children: PropTypes.node,
+  noWrapper: PropTypes.bool,
   debug: PropTypes.bool,
   onEnter: PropTypes.func,
   onLeave: PropTypes.func,


### PR DESCRIPTION
Addresses #112 
Intended to supersede #41 

If you pass children to a Waypoint element, `onEnter` will be triggered when the element is fully or partially within the viewport, or if it fully encloses the viewpoint. `onLeave` will be triggered when no part of the element is within the viewport. 

This does not differentiate between full, partial, or enclosing visibility. That would likely require API changes (eg; a parameter being passed to `onEnter` and `onLeave`, new callbacks like `onPartialEnter`, or a new callback with a parameter, eg `onChange(visibility: Enum<'full'|'partial'|'enclosing'|'none'>`). Leaving as a TODO. 

I haven't added tests yet, so this isn't ready to merge. In the meantime, though, here's a screencast: 

![waypoint_scroll_demo_short_720](https://cloud.githubusercontent.com/assets/704302/22302321/11b9c66a-e2e3-11e6-98bb-d3165179d458.gif)