### PR TITLE
Update to allow for dynamic offset values

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ below) has changed.
     topOffset: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
+      PropTypes.func,
     ]),
 
     /**
@@ -127,6 +128,7 @@ below) has changed.
     bottomOffset: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
+      PropTypes.func,
     ]),
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,12 +64,12 @@ declare namespace ReactWaypoint {
 
         /**
          * `topOffset` can either be a number, in which case its a distance from the
-         * top of the container in pixels, or a string value. Valid string values are
-         * of the form "20px", which is parsed as pixels, or "20%", which is parsed
-         * as a percentage of the height of the containing element.
-         * For instance, if you pass "-20%", and the containing element is 100px tall,
-         * then the waypoint will be triggered when it has been scrolled 20px beyond
-         * the top of the containing element.
+         * top of the container in pixels, a string value, or a function that returns
+         * a number. Valid string values are of the form "20px", which is parsed as
+         * pixels, or "20%", which is parsed as a percentage of the height of the
+         * containing element. For instance, if you pass "-20%", and the containing
+         * element is 100px tall, then the waypoint will be triggered when it has
+         * been scrolled 20px beyond the top of the containing element.
          */
         topOffset?: string|number;
 

--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -34,6 +34,8 @@ describe('<Waypoint>', function() {
 
     this.margin = 10;
     this.parentHeight = 100;
+    this.topSpacerHeight = 0;
+    this.bottomSpacerHeight = 0;
 
     this.parentStyle = {
       height: this.parentHeight,
@@ -42,9 +44,6 @@ describe('<Waypoint>', function() {
       width: 100,
       margin: this.margin, //Normalize the space above the viewport.
     };
-
-    this.topSpacerHeight = 0;
-    this.bottomSpacerHeight = 0;
 
     this.subject = () => {
       const el = renderAttached(
@@ -229,6 +228,45 @@ describe('<Waypoint>', function() {
           waypointTop: this.margin + this.topSpacerHeight,
           viewportTop: this.margin - (this.parentHeight * 2),
           viewportBottom: this.margin + (this.parentHeight * 3),
+        });
+    });
+
+    it('does not call the onLeave handler', () => {
+      expect(this.props.onLeave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the Waypoint is visible on mount and has a dynamic topOffset', () => {
+    beforeEach(() => {
+      this.props.topOffset = () => 3 + 2;
+      this.props.bottomOffset = 0;
+
+      this.topSpacerHeight = 10;
+      this.bottomSpacerHeight = 10;
+      this.parentComponent = this.subject();
+      this.scrollable = this.parentComponent;
+    });
+
+    it('calls the onEnter handler', () => {
+      expect(this.props.onEnter).toHaveBeenCalledWith({
+        currentPosition: Waypoint.inside,
+        previousPosition: undefined,
+        event: null,
+        waypointTop: this.margin + this.topSpacerHeight,
+        viewportTop: this.margin + 5,
+        viewportBottom: this.margin + this.parentHeight,
+      });
+    });
+
+    it('calls the onPositionChange handler', () => {
+      expect(this.props.onPositionChange).
+        toHaveBeenCalledWith({
+          currentPosition: Waypoint.inside,
+          previousPosition: undefined,
+          event: null,
+          waypointTop: this.margin + this.topSpacerHeight,
+          viewportTop: this.margin + 5,
+          viewportBottom: this.margin + this.parentHeight,
         });
     });
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -90,18 +90,19 @@ function parseOffsetAsPercentage(str) {
 }
 
 /**
- * @param {string|number} offset
+ * @param {string|number|function(int)} offset
  * @param {number} contextHeight
  * @return {number} A number representing `offset` converted into pixels.
  */
 function computeOffsetPixels(offset, contextHeight) {
-  const pixelOffset = parseOffsetAsPixels(offset);
+  const offsetValue = typeof offset === 'function' ? offset.call(this) : offset;
+  const pixelOffset = parseOffsetAsPixels(offsetValue);
 
   if (typeof pixelOffset === 'number') {
     return pixelOffset;
   }
 
-  const percentOffset = parseOffsetAsPercentage(offset);
+  const percentOffset = parseOffsetAsPercentage(offsetValue);
   if (typeof percentOffset === 'number') {
     return percentOffset * contextHeight;
   }
@@ -358,12 +359,14 @@ Waypoint.propTypes = {
   topOffset: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
+    PropTypes.func,
   ]),
 
   // `bottomOffset` is like `topOffset`, but for the bottom of the container.
   bottomOffset: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
+    PropTypes.func,
   ]),
 };
 


### PR DESCRIPTION
I needed the capability to change the offset value based on some factors that Waypoint couldn’t (and shouldn’t) be aware of. The easiest way to do this was to use a function for `topOffset` that calculates the appropriate offset based on current app state:

```
topOffset={ () => this.state.licenseBarInView ? HCo.licenseBar.enterOffset : HCo.licenseBar.leaveOffset }
```

In my case that translates to `topOffset={ () => this.state.licenseBarInView ? 20 : 104 }`

Let me know if you think this is a viable change, and if I’ve missed anything here!

Thanks.