### PR TITLE
Remove scss-lint link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,9 +375,8 @@ Thanks to the creator of the original Waypoints library,
 ---
 
 _Make sure to check out other popular open-source tools from
-[the Brigade team][brigade-github]: [scss-lint], [overcommit], and [haml-lint]._
+[the Brigade team][brigade-github]: [overcommit] and [haml-lint].
 
 [brigade-github]: https://github.com/brigade
-[scss-lint]: https://github.com/brigade/scss-lint
 [overcommit]: https://github.com/brigade/overcommit
 [haml-lint]: https://github.com/brigade/haml-lint


### PR DESCRIPTION
Since scss-lint is basically in maintenance mode, it
doesn't seem right to direct people in that direction
anymore.

https://github.com/brigade/scss-lint/commit/4ac76f95