### PR TITLE
Teach scrollableAncestor prop to take "window" as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ enters or leaves the viewport. For details, see [Children](#children), below.
      * the container. For example, when your target is in a div
      * that has overflow auto but you are detecting onEnter based
      * on the window.
+     *
+     * This should typically be a reference to a DOM node, but it will also work
+     * to pass it the string "window" if you are using server rendering.
      */
     scrollableAncestor: PropTypes.any,
 
@@ -296,8 +299,12 @@ first scrollable ancestor of the Waypoint.
 
 If that algorithm doesn't work for your use case, then you might find the
 `scrollableAncestor` prop useful. It allows you to specify what the scrollable
-ancestor is. Pass a node as that prop, and the Waypoint will use the scroll
-position of *that* node, rather than its first scrollable ancestor.
+ancestor is. Pass a reference to a DOM node as that prop, and the Waypoint will
+use the scroll position of *that* node, rather than its first scrollable
+ancestor.
+
+This can also be the string "window", which can be useful if you are using
+server rendering.
 
 #### Example Usage
 

--- a/spec/resolveScrollableAncestorProp_spec.js
+++ b/spec/resolveScrollableAncestorProp_spec.js
@@ -1,0 +1,11 @@
+import resolveScrollableAncestorProp from '../src/resolveScrollableAncestorProp';
+
+describe('resolveScrollableAncestorProp()', () => {
+  it('converts "window" into `global.window`', () => {
+    expect(resolveScrollableAncestorProp('window')).toEqual(global.window);
+  });
+
+  it('passes other values through', () => {
+    expect(resolveScrollableAncestorProp('foo')).toEqual('foo');
+  });
+});

--- a/src/computeOffsetPixels.js
+++ b/src/computeOffsetPixels.js
@@ -1,0 +1,20 @@
+import parseOffsetAsPercentage from './parseOffsetAsPercentage';
+import parseOffsetAsPixels from './parseOffsetAsPixels';
+
+/**
+ * @param {string|number} offset
+ * @param {number} contextHeight
+ * @return {number} A number representing `offset` converted into pixels.
+ */
+export default function computeOffsetPixels(offset, contextHeight) {
+  const pixelOffset = parseOffsetAsPixels(offset);
+
+  if (typeof pixelOffset === 'number') {
+    return pixelOffset;
+  }
+
+  const percentOffset = parseOffsetAsPercentage(offset);
+  if (typeof percentOffset === 'number') {
+    return percentOffset * contextHeight;
+  }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,6 @@
+export default {
+  above: 'above',
+  inside: 'inside',
+  below: 'below',
+  invisible: 'invisible',
+};

--- a/src/debugLog.js
+++ b/src/debugLog.js
@@ -1,0 +1,5 @@
+export default function debugLog() {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(arguments); // eslint-disable-line no-console
+  }
+}

--- a/src/ensureChildrenIsSingleDOMElement.js
+++ b/src/ensureChildrenIsSingleDOMElement.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import isDOMElement from './isDOMElement';
+
+/**
+ * Raise an error if "children" isn't a single DOM Element
+ *
+ * @param {React.element|null} children
+ * @return {undefined}
+ */
+export default function ensureChildrenIsSingleDOMElement(children) {
+  if (children) {
+    React.Children.only(children);
+
+    if (!isDOMElement(children)) {
+      throw new Error(
+        'You must wrap any Component Elements passed to Waypoint in a DOM Element (eg; a <div>).'
+      );
+    }
+  }
+}

--- a/src/getCurrentPosition.js
+++ b/src/getCurrentPosition.js
@@ -1,0 +1,42 @@
+import constants from './constants';
+
+/**
+ * @param {object} bounds An object with bounds data for the waypoint and
+ *   scrollable parent
+ * @return {string} The current position of the waypoint in relation to the
+ *   visible portion of the scrollable parent. One of `constants.above`,
+ *   `constants.below`, or `constants.inside`.
+ */
+export default function getCurrentPosition(bounds) {
+  if (bounds.viewportBottom - bounds.viewportTop === 0) {
+    return constants.invisible;
+  }
+
+  // top is within the viewport
+  if (bounds.viewportTop <= bounds.waypointTop &&
+      bounds.waypointTop <= bounds.viewportBottom) {
+    return constants.inside;
+  }
+
+  // bottom is within the viewport
+  if (bounds.viewportTop <= bounds.waypointBottom &&
+      bounds.waypointBottom <= bounds.viewportBottom) {
+    return constants.inside;
+  }
+
+  // top is above the viewport and bottom is below the viewport
+  if (bounds.waypointTop <= bounds.viewportTop &&
+      bounds.viewportBottom <= bounds.waypointBottom) {
+    return constants.inside;
+  }
+
+  if (bounds.viewportBottom < bounds.waypointTop) {
+    return constants.below;
+  }
+
+  if (bounds.waypointTop < bounds.viewportTop) {
+    return constants.above;
+  }
+
+  return constants.invisible;
+}

--- a/src/isDOMElement.js
+++ b/src/isDOMElement.js
@@ -1,0 +1,10 @@
+/**
+ * When an element's type is a string, it represents a DOM node with that tag name
+ * https://facebook.github.io/react/blog/2015/12/18/react-components-elements-and-instances.html#dom-elements
+ *
+ * @param {React.element} Component
+ * @return {bool} Whether the component is a DOM Element
+ */
+export default function isDOMElement(Component) {
+  return (typeof Component.type === 'string');
+}

--- a/src/parseOffsetAsPercentage.js
+++ b/src/parseOffsetAsPercentage.js
@@ -1,0 +1,17 @@
+/**
+ * Attempts to parse the offset provided as a prop as a percentage. For
+ * instance, if the component has been provided with the string "20%" as
+ * a value of one of the offset props. If the value matches, then it returns
+ * a numeric version of the prop. For instance, "20%" would become `0.2`.
+ * If `str` isn't a percentage, then `undefined` will be returned.
+ *
+ * @param {string} str The value of an offset prop to be converted to a
+ *   number.
+ * @return {number|undefined} The numeric version of `str`. Undefined if `str`
+ *   was not a percentage.
+ */
+export default function parseOffsetAsPercentage(str) {
+  if (str.slice(-1) === '%') {
+    return parseFloat(str.slice(0, -1)) / 100;
+  }
+}

--- a/src/parseOffsetAsPixels.js
+++ b/src/parseOffsetAsPixels.js
@@ -1,0 +1,20 @@
+/**
+ * Attempts to parse the offset provided as a prop as a pixel value. If
+ * parsing fails, then `undefined` is returned. Three examples of values that
+ * will be successfully parsed are:
+ * `20`
+ * "20px"
+ * "20"
+ *
+ * @param {string|number} str A string of the form "{number}" or "{number}px",
+ *   or just a number.
+ * @return {number|undefined} The numeric version of `str`. Undefined if `str`
+ *   was neither a number nor string ending in "px".
+ */
+export default function parseOffsetAsPixels(str) {
+  if (!isNaN(parseFloat(str)) && isFinite(str)) {
+    return parseFloat(str);
+  } else if (str.slice(-2) === 'px') {
+    return parseFloat(str.slice(0, -2));
+  }
+}

--- a/src/resolveScrollableAncestorProp.js
+++ b/src/resolveScrollableAncestorProp.js
@@ -1,0 +1,10 @@
+export default function resolveScrollableAncestorProp(scrollableAncestor) {
+  // When Waypoint is rendered on the server, `window` is not available.
+  // To make Waypoint easier to work with, we allow this to be specified in
+  // string form and safely convert to `window` here.
+  if (scrollableAncestor === 'window') {
+    return global.window;
+  }
+
+  return scrollableAncestor;
+}

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -6,6 +6,7 @@ import constants from './constants';
 import debugLog from './debugLog';
 import ensureChildrenIsSingleDOMElement from './ensureChildrenIsSingleDOMElement';
 import getCurrentPosition from './getCurrentPosition';
+import resolveScrollableAncestorProp from './resolveScrollableAncestorProp';
 
 const defaultProps = {
   topOffset: '0px',
@@ -102,8 +103,13 @@ export default class Waypoint extends React.Component {
    *   as a fallback.
    */
   _findScrollableAncestor() {
-    if (this.props.scrollableAncestor) {
-      return this.props.scrollableAncestor;
+    const {
+      horizontal,
+      scrollableAncestor,
+    } = this.props;
+
+    if (scrollableAncestor) {
+      return resolveScrollableAncestorProp(scrollableAncestor);
     }
 
     let node = this._ref;
@@ -122,7 +128,7 @@ export default class Waypoint extends React.Component {
       }
 
       const style = window.getComputedStyle(node);
-      const overflowDirec = this.props.horizontal ?
+      const overflowDirec = horizontal ?
         style.getPropertyValue('overflow-x') :
         style.getPropertyValue('overflow-y');
       const overflow = overflowDirec || style.getPropertyValue('overflow');


### PR DESCRIPTION
When Waypoint is rendered on the server, `window` is not available.
To make Waypoint easier to work with, we allow this to be specified in
string form and safely convert to `window` here.

While I was at it, I also broke out a bunch of functions into their own
modules to make it easier to work with this project and to eventually
improve our testing story. This is probably best reviewed
commit-by-commit.

semver minor