### PR TITLE
Avoid unnecessary clearTimeout when unmounting

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -66,6 +66,7 @@ export default class Waypoint extends React.Component {
     // this works smoothly, we want to delay the initial execution until the
     // next tick.
     this.initialTimeout = setTimeout(() => {
+      this.initialTimeout = null;
       this._handleScroll(null);
     }, 0);
   }
@@ -91,7 +92,9 @@ export default class Waypoint extends React.Component {
     removeEventListener(this.scrollEventListenerHandle);
     removeEventListener(this.resizeEventListenerHandle);
 
-    clearTimeout(this.initialTimeout);
+    if (this.initialTimeout) {
+      clearTimeout(this.initialTimeout);
+    }
   }
 
   /**


### PR DESCRIPTION
I was doing some profiling and noticed a pattern on pages that have a
lot of waypoints. In the timeline I can see that we spend a non-trivial
amount of time in clearTimeout (~0.25ms per waypoint on my laptop). This
can add up, so let's avoid the extra work by adding a check.

![screen shot 2017-03-28 at 6 25 55 pm](https://cloud.githubusercontent.com/assets/195534/24434389/0ce458b2-13e4-11e7-867f-a432c57db65f.png)
