### PR TITLE
Remove prop-types peerDep; 5.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## master (unreleased)
 
+## 5.3.1
+
+- Remove the `prop-types` peer dependency. This was an accidental breaking
+  change that will instead be released as 6.0.0.
+
 ## 5.3.0
 
 - Remove deprecation warnings when running on React 15.5

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "author": "Brigade Engineering",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "prop-types": "^15.0.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "@types/react": "^15.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-waypoint",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A React component to execute a function whenever you scroll to an element.",
   "main": "build/waypoint.js",
   "types": "index.d.ts",

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -1,6 +1,5 @@
 import { addEventListener, removeEventListener } from 'consolidated-events';
-import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 import computeOffsetPixels from './computeOffsetPixels';
 import constants from './constants';


### PR DESCRIPTION
Rather than revert the 4 commits in #172 (most of which are changes that we _do_ want), I just undid the part that was breaking peoples' builds.

Let me know how this looks, and I'll merge and release. Working on the 6.0.0 branch now (which will just `revert` fca1ebb )

Resolves #174 