### PR TITLE
Add offset and boundary images to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ then the boundaries will be pushed inward, toward the center of the page. If
 you specify a negative value for an offset, then the boundary will be pushed
 outward from the center of the page.
 
+Here is an illustration of offsets and boundaries. The black box is the
+[`scrollableAncestor`](#containing-elements-and-scrollableancestor). The pink
+lines represent the location of the boundaries. The offsets that determine
+the boundaries are in light pink.
+
+![](https://cloud.githubusercontent.com/assets/2322305/16939123/5be12454-4d33-11e6-86b6-ad431da93bf2.png)
+
 #### Horizontal Scrolling Offsets and Boundaries
 
 By default, waypoints listen to vertical scrolling. If you want to switch to


### PR DESCRIPTION
_Forever ago_ in #108, I drew up some images to show how the offsets and boundaries work. @trotzig recommended I add them to the README, and well, I intended to but never did. Whoops.

This finally adds them. There are probably improvements that could be made, but maybe this is a good place to start. What do y'all think?

//cc @xeophin