### PR TITLE
Restrict lower bound of React to v0.14.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Brigade Engineering",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
+    "react": "^0.14.9 || ^15.0.0",
     "prop-types": "^15.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Depending on how broken the `prop-types` lib is in `< 0.14.9`, I could see this going out as either a major release, or a bug fix. Because they had to cut a new React version, my guess is that it's probably pretty broken, so I could see it going out as a bug fix.

Has anyone experienced using `prop-types` in `< 0.14.9`?

---

Resolves #179