### PR TITLE
Move prop-types to a proper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   ],
   "dependencies": {
     "consolidated-events": "^1.0.1",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,13 +25,11 @@
     "testonly": "karma start --single-run",
     "testonly:watch": "karma start --no-single-run",
     "performance-test:watch": "webpack --watch --config webpack.config.performance-test.js"
-
   },
   "author": "Brigade Engineering",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.0.0",
-    "prop-types": "^15.0.0"
+    "react": "^0.14.9 || ^15.0.0"
   },
   "devDependencies": {
     "@types/react": "^15.0.21",
@@ -52,7 +50,6 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.0",
     "karma-webpack": "^2.0.3",
-    "prop-types": "^15.5.4",
     "react": "^15.5.3",
     "react-dom": "^15.5.3",
     "rimraf": "^2.6.1",
@@ -67,6 +64,7 @@
     "onscroll"
   ],
   "dependencies": {
-    "consolidated-events": "^1.0.1"
+    "consolidated-events": "^1.0.1",
+    "prop-types": "^15.5.8"
   }
 }


### PR DESCRIPTION
This resolves some of the discussion in #179. The prop-types package is
small enough to not worry about duplicates ending up in peoples
(webpack/browserify) bundles. Also, other projects are also taking the
same ease-of-installation+dupes-don't-matter approach:

  - React Router
  https://github.com/ReactTraining/react-router/blob/ed6f3de4ea8baf950e65fd35e6785e0b493fb9e6/packages/react-router/package.json#L44

  - Redux-form
  https://github.com/erikras/redux-form/blob/4e7f5cfe5f34d2cf02cca841366d58196d330e35/package.json#L64