### PR TITLE
Assume `window` as scrollableAncestor for <body>

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -1138,9 +1138,17 @@ describe('<Waypoint>', function() {
       this.parentStyle.height = 'auto';
       this.parentStyle.overflow = 'visible';
 
+      // This is only here to try and confuse the _findScrollableAncestor code.
+      document.body.style.overflow = 'auto';
+
       // Make the spacers large enough to make the Waypoint render off-screen
       this.topSpacerHeight = window.innerHeight + 1000;
       this.bottomSpacerHeight = 1000;
+    });
+
+    afterEach(() => {
+      // Reset body style
+      document.body.style.overflow = '';
     });
 
     it('does not fire the onEnter handler on mount', () => {

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -121,14 +121,9 @@ export default class Waypoint extends React.Component {
     while (node.parentNode) {
       node = node.parentNode;
 
-      if (node === document) {
-        // This particular node does not have a computed style.
-        continue;
-      }
-
-      if (node === document.documentElement) {
-        // This particular node does not have a scroll bar, it uses the window.
-        continue;
+      if (node === document.body) {
+        // We've reached all the way to the root node.
+        return window;
       }
 
       const style = window.getComputedStyle(node);


### PR DESCRIPTION
We've seen reports (e.g. [1], [2]) where people have to add
`scrollableAncestor={window}`, because their <body> element has an
overflow style that is either "auto" or "scroll". Unless I'm mistaken,
there's no way to make the body scroll independently, which means that
we can assume that the element to attach scroll listeners to is
`window`.

Making this assumption led to a bit of simplification around a few
exceptions we had made when traversing up the DOM tree. Once we reach
`document.body`, we simply return. I can't think of a scenario where we
would want to continue traversing from that node.

[1] #171
[2] #182