### PR TITLE
Improve startup time

### DIFF
--- a/spec/waypoint_spec.js
+++ b/spec/waypoint_spec.js
@@ -1239,8 +1239,14 @@ describe('<Waypoint>', function() {
 
     it('only calls onEnter once', () => {
       this.subject();
-      scrollNodeTo(window, window.innerHeight);
-      expect(this.props.onEnter.calls.count()).toBe(1);
+
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          scrollNodeTo(window, window.innerHeight);
+          expect(this.props.onEnter.calls.count()).toBe(1);
+          resolve();
+        });
+      });
     });
   });
 

--- a/src/onNextTick.js
+++ b/src/onNextTick.js
@@ -1,0 +1,36 @@
+let timeout;
+const timeoutQueue = [];
+
+export default function onNextTick(cb) {
+  timeoutQueue.push(cb);
+
+  if (!timeout) {
+    timeout = setTimeout(() => {
+      timeout = null;
+
+      // Drain the timeoutQueue
+      let item;
+      // eslint-disable-next-line no-cond-assign
+      while (item = timeoutQueue.shift()) {
+        item();
+      }
+    }, 0);
+  }
+
+  let isSubscribed = true;
+
+  return function unsubscribe() {
+    if (!isSubscribed) {
+      return;
+    }
+
+    isSubscribed = false;
+    const index = timeoutQueue.indexOf(cb);
+    timeoutQueue.splice(index, 1);
+
+    if (!timeoutQueue.length && timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
+}


### PR DESCRIPTION
While doing some profiling, I noticed that on pages that render a lot of
waypoints, a lot of time is spent in componentDidMount. This is mostly
due to the cost of calling setTimeout, but also because of the other
work we are doing in here, like findScrollableAncestor.

By consolidating the setTimout calls, we greatly reduce the cost of
componentDidMount. We can take this a step further and defer
initializing the event listeners and finding the scrollable ancestors
since we won't need any of that anyway until our initial handleScroll
call can happen. This effectively makes componentDidMount free, which
frees up the main thread for more important work, like rendering pixels.

I believe that this also allows the calls to findScrollableAncestor to
work faster by avoiding some layout thrashing. Since this function
traverses up the DOM tree and computes styles on a bunch of nodes, this
is important. When these operations happened in componentDidMount, it is
possible that other components would invalidate layout in between these
calls from multiple waypoints. By clustering all of them together, we
are less likely to have to recalculate style or compute layout every
time.

Additionally, there may be cases where waypoints are rendered and
unmounted very quickly. In this case, we might actually be able to avoid
some of the unnecessary work we are doing here, which will be a small
win for those situations.

The main drawback to this is that if you have a lot of waypoints on a
page, the previous approach keeps each initial run a bit more async,
which allows the browser to do work in between. Now, all of that work is
in the same block. I think this is an acceptable tradeoff.

Here are some flame charts I generated on a page that has a lot of waypoints (close to 100 I think).

componentDidMount Before (most of those orange blocks are calls to setTimeout):

<img width="761" alt="screen shot 2017-05-05 at 10 45 49 am" src="https://cloud.githubusercontent.com/assets/195534/25758030/ca1ce52e-3181-11e7-9fdf-73ed58faf5e3.png">

componentDidMount after consolidating setTimeout only:

<img width="448" alt="screen shot 2017-05-05 at 10 45 41 am" src="https://cloud.githubusercontent.com/assets/195534/25758050/de1a609c-3181-11e7-92a3-67a6169bb18b.png">

componentDidMount after moving everything into the callback (almost all of the time left is spent in other components that are not waypoint):

<img width="480" alt="screen shot 2017-05-05 at 10 46 00 am" src="https://cloud.githubusercontent.com/assets/195534/25758059/ed3340c6-3181-11e7-9b02-4edaffff1a7a.png">

timeouts being called before this change:

<img width="1003" alt="screen shot 2017-05-05 at 10 48 04 am" src="https://cloud.githubusercontent.com/assets/195534/25758094/04b7c992-3182-11e7-9bb4-527164974311.png">

timeouts being called after this change:

<img width="610" alt="screen shot 2017-05-05 at 10 48 31 am" src="https://cloud.githubusercontent.com/assets/195534/25758103/0c34e18c-3182-11e7-9bce-ef37bbe150eb.png">
