### PR TITLE
Fix bug if waypoint updates before being initialized

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -81,6 +81,11 @@ export default class Waypoint extends React.Component {
       return;
     }
 
+    if (!this.scrollableAncestor) {
+      // The Waypoint has not yet initialized.
+      return;
+    }
+
     // The element may have moved.
     this._handleScroll(null);
   }


### PR DESCRIPTION
After trying out v7.0.1, I spotted an error that would happen if the
waypoint was updated before it had a chance to initialize. Since we call
handleScroll when the component updates, which calls getBounds, which
then tries to access the offsetHeight on this.scrollableAncestor, we
expect that this.scrollableAncestor has been defined. But, if the
component updates before the deferred initialization has run, then this
is undefined and we get an error.

I don't have time to write a test for this just now, but I've tried it
out in my app and it fixes the issue so I want to get it released before
much longer.