### PR TITLE
fix onNextTick

### DIFF
--- a/src/onNextTick.js
+++ b/src/onNextTick.js
@@ -17,15 +17,12 @@ export default function onNextTick(cb) {
     }, 0);
   }
 
-  let isSubscribed = true;
-
   return function unsubscribe() {
-    if (!isSubscribed) {
+    const index = timeoutQueue.indexOf(cb);
+    if (index === -1) {
       return;
     }
 
-    isSubscribed = false;
-    const index = timeoutQueue.indexOf(cb);
     timeoutQueue.splice(index, 1);
 
     if (!timeoutQueue.length && timeout) {


### PR DESCRIPTION
The PR [Improve startup time](https://github.com/brigade/react-waypoint/pull/188) has introduced a function named `onNextTick` for performance reason to invoke the callback in a batch way. However, it also introduces a bug there.

The basic logic is:

- When the queue being consumed, it will shift its items one by one.
- When the component will unmount, it will unregister from the queue.

The problem is when step2 will wrongly remove something after step 1 gets finished.

```
    if (!isSubscribed) { // this guard value doesn't work
      return;
    }

    isSubscribed = false;
    const index = timeoutQueue.indexOf(cb); // the index could get -1
    timeoutQueue.splice(index, 1);  // almost remove everything from the queue
```

How to reproduce?

- register [cb1, cb2, cb3]
- consume cb1, cb2, cb3
- register [cb4, cb5, cb6]
- unregister [cb1]
- *notice: cb4, cb5 will be removed by unregister cb1*

As I don't have enough time to set up the karma environment. I didn't write up test cases for it and hope the code is straight forward enough.

@lencioni please take a look. Thanks.