### PR TITLE
Add node 7 and 8 to Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 sudo: false
 node_js:
+  - '8'
+  - '7'
   - '6'
   - '5'
   - '4'


### PR DESCRIPTION
This will help us make sure that react-waypoint continues to work for
folks running newer versions of node.