### PR TITLE
Build with rollup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,3 @@
 {
-  "plugins": [
-    "transform-react-jsx",
-    "add-module-exports"
-  ],
-  "presets": ["es2015"]
+  "presets": [["airbnb", { "modules": false }]]
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-waypoint",
   "version": "7.2.0",
   "description": "A React component to execute a function whenever you scroll to an element.",
-  "main": "build/index.cjs.js",
-  "module": "build/index.esm.js",
+  "main": "build/index.js",
+  "module": "build/index.mjs",
   "types": "index.d.ts",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "react-waypoint",
   "version": "7.2.0",
   "description": "A React component to execute a function whenever you scroll to an element.",
-  "main": "build/waypoint.js",
+  "main": "build/index.cjs.js",
+  "module": "build/index.esm.js",
   "types": "index.d.ts",
   "repository": {
     "type": "git",
@@ -11,7 +12,7 @@
   "homepage": "https://github.com/brigade/react-waypoint",
   "bugs": "https://github.com/brigade/react-waypoint/issues",
   "scripts": {
-    "build": "npm run clean && babel src/ -d build/",
+    "build": "npm run clean && rollup -c",
     "check-changelog": "expr $(git status --porcelain 2>/dev/null| grep \"^\\s*M.*CHANGELOG.md\" | wc -l) >/dev/null || (echo 'Please edit CHANGELOG.md' && exit 1)",
     "check-only-changelog-changed": "(expr $(git status --porcelain 2>/dev/null| grep -v \"CHANGELOG.md\" | wc -l) >/dev/null && echo 'Only CHANGELOG.md may have uncommitted changes' && exit 1) || exit 0",
     "clean": "rimraf build",
@@ -36,9 +37,7 @@
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
     "babel-loader": "^6.4.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-react-jsx": "^6.23.0",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-airbnb": "^2.4.0",
     "eslint": "^3.17.1",
     "eslint-config-brigade": "^3.2.1",
     "eslint-plugin-react": "^6.10.0",
@@ -53,6 +52,8 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "rimraf": "^2.6.1",
+    "rollup": "^0.50.0",
+    "rollup-plugin-babel": "^3.0.2",
     "safe-publish-latest": "^1.1.1",
     "webpack": "^2.3.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,21 @@
+import babel from 'rollup-plugin-babel';
+import pkg from './package.json';
+
+export default [
+  {
+    entry: 'src/waypoint.jsx',
+    external: [
+      ...Object.keys(pkg.dependencies),
+      ...Object.keys(pkg.peerDependencies),
+    ],
+    targets: [
+      { dest: pkg.main, format: 'cjs' },
+      { dest: pkg.module, format: 'es' }
+    ],
+    plugins: [
+      babel({
+        exclude: ['node_modules/**']
+      })
+    ]
+  }
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,14 +3,14 @@ import pkg from './package.json';
 
 export default [
   {
-    entry: 'src/waypoint.jsx',
+    input: 'src/waypoint.jsx',
     external: [
       ...Object.keys(pkg.dependencies),
       ...Object.keys(pkg.peerDependencies),
     ],
-    targets: [
-      { dest: pkg.main, format: 'cjs' },
-      { dest: pkg.module, format: 'es' }
+    output: [
+      { file: pkg.main, format: 'cjs' },
+      { file: pkg.module, format: 'es' }
     ],
     plugins: [
       babel({


### PR DESCRIPTION
Previously, we were building waypoint just by running it through Babel.
Since we split things out into separate modules, this caused a bit of
extra overhead in the bundle size and at runtime due to the extra
wrapping of these modules.

Thankfully, rollup was built to help us produce a smaller build. To make
this work, I needed to remove the Babel configuration that specifies a
module transformer, so I decided to switch to the Airbnb Babel preset,
which exposes an option for this (and under the hood uses
babel-preset-env, which we need to migrate to anyway). More info:

  https://github.com/rollup/rollup-plugin-babel#configuring-babel

The rest of this was loosely based off the rollup-starter-lib
configuration. This gives us an ESM build pretty much for free.

  https://github.com/rollup/rollup-starter-lib/tree/babel