### PR TITLE
Fix test failing because of react error boundaries

### DIFF
--- a/test/waypoint_test.jsx
+++ b/test/waypoint_test.jsx
@@ -873,7 +873,7 @@ describe('<Waypoint>', function() {
 
     it('errors when multiple children are provided', () => {
       // INFO: React 16 throws user errorrs again by it's own in dev mode, see:
-      // https://github.com/facebook/react/blob/e932ad68bed656eed5295b61ba74e5d0857902ed/src/renderers/shared/fiber/ReactFiberErrorLogger.js#L65
+      // https://github.com/facebook/react/issues/10384#issuecomment-334142138
       //
       // This code ignores uncaught errors and prevents test from failing in React 16
       window.onerror = () => undefined;

--- a/test/waypoint_test.jsx
+++ b/test/waypoint_test.jsx
@@ -871,12 +871,20 @@ describe('<Waypoint>', function() {
       expect(this.subject).not.toThrow();
     });
 
-    xit('errors when multiple children are provided', () => {
+    it('errors when multiple children are provided', (done) => {
       this.props.children = [
         <div key={1} />,
         <div key={2} />,
         <div key={3} />,
       ];
+
+      window.onerror = () => {
+        // INFO: React 16 throws user errorrs again by it's own in dev mode, see:
+        // https://github.com/facebook/react/blob/e932ad68bed656eed5295b61ba74e5d0857902ed/src/renderers/shared/fiber/ReactFiberErrorLogger.js#L65
+        //
+        // This hack prevents tests from failing after uncaught exception is thrown by React
+        done();
+      };
 
       expect(this.subject).toThrowError(notValidErrorMessage);
     });

--- a/test/waypoint_test.jsx
+++ b/test/waypoint_test.jsx
@@ -872,7 +872,7 @@ describe('<Waypoint>', function() {
     });
 
     it('errors when multiple children are provided', () => {
-      // INFO: React 16 throws user errorrs again by it's own in dev mode, see:
+      // INFO: React 16 throws user errors again by it's own in dev mode, see:
       // https://github.com/facebook/react/issues/10384#issuecomment-334142138
       //
       // This code ignores uncaught errors and prevents test from failing in React 16

--- a/test/waypoint_test.jsx
+++ b/test/waypoint_test.jsx
@@ -871,22 +871,22 @@ describe('<Waypoint>', function() {
       expect(this.subject).not.toThrow();
     });
 
-    it('errors when multiple children are provided', (done) => {
+    it('errors when multiple children are provided', () => {
+      // INFO: React 16 throws user errorrs again by it's own in dev mode, see:
+      // https://github.com/facebook/react/blob/e932ad68bed656eed5295b61ba74e5d0857902ed/src/renderers/shared/fiber/ReactFiberErrorLogger.js#L65
+      //
+      // This code ignores uncaught errors and prevents test from failing in React 16
+      window.onerror = () => undefined;
+
       this.props.children = [
         <div key={1} />,
         <div key={2} />,
         <div key={3} />,
       ];
 
-      window.onerror = () => {
-        // INFO: React 16 throws user errorrs again by it's own in dev mode, see:
-        // https://github.com/facebook/react/blob/e932ad68bed656eed5295b61ba74e5d0857902ed/src/renderers/shared/fiber/ReactFiberErrorLogger.js#L65
-        //
-        // This hack prevents tests from failing after uncaught exception is thrown by React
-        done();
-      };
-
       expect(this.subject).toThrowError(notValidErrorMessage);
+
+      window.onerror = undefined;
     });
 
     it('does not throw with a Stateful Component as a child', () => {

--- a/test/waypoint_test.jsx
+++ b/test/waypoint_test.jsx
@@ -876,6 +876,7 @@ describe('<Waypoint>', function() {
       // https://github.com/facebook/react/issues/10384#issuecomment-334142138
       //
       // This code ignores uncaught errors and prevents test from failing in React 16
+      const prevOnError = window.onerror;
       window.onerror = () => undefined;
 
       this.props.children = [
@@ -886,7 +887,7 @@ describe('<Waypoint>', function() {
 
       expect(this.subject).toThrowError(notValidErrorMessage);
 
-      window.onerror = undefined;
+      window.onerror = prevOnError;
     });
 
     it('does not throw with a Stateful Component as a child', () => {


### PR DESCRIPTION
Fixing the test that was disabled due to the React 16 error boundaries handling: https://github.com/brigade/react-waypoint/pull/215#issuecomment-333627647

I found out that with error boundaries, error throws twice in development mode, here is a justification for that from React team: https://github.com/facebook/react/issues/10384#issuecomment-334142138

I found a fix for that although it looks a little hacky. The other option could be to run tests in `production` mode, but that breaks debug tests and I'm not sure how to fix this.