### PR TITLE
Make ES module opt-in

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 build
+es
+cjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
+es
+cjs
 node_modules
 npm-debug.log
 .idea/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import Waypoint from 'react-waypoint';
 ```
 
 *Alternatively, you can also use the ES module that this package provides:
-`import Waypoint from 'react-waypoint/build/index.mjs'`.*
+`import Waypoint from 'react-waypoint/es'`.*
 
 A waypoint normally fires `onEnter` and `onLeave` as you are scrolling, but it
 can fire because of other events too:

--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ yarn add react-waypoint
 ## Usage
 
 ```jsx
-var Waypoint = require('react-waypoint');
-```
+import Waypoint from 'react-waypoint';
 
-```jsx
 <Waypoint
   onEnter={this._handleWaypointEnter}
   onLeave={this._handleWaypointLeave}
 />
 ```
+
+*Alternatively, you can also use the ES module that this package provides:
+`import Waypoint from 'react-waypoint/build/index.mjs'`.*
 
 A waypoint normally fires `onEnter` and `onLeave` as you are scrolling, but it
 can fire because of other events too:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-waypoint",
   "version": "7.3.0",
   "description": "A React component to execute a function whenever you scroll to an element.",
-  "main": "build/index.js",
+  "main": "cjs/index.js",
   "types": "index.d.ts",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
     "build": "npm run clean && rollup -c",
     "check-changelog": "expr $(git status --porcelain 2>/dev/null| grep \"^\\s*M.*CHANGELOG.md\" | wc -l) >/dev/null || (echo 'Please edit CHANGELOG.md' && exit 1)",
     "check-only-changelog-changed": "(expr $(git status --porcelain 2>/dev/null| grep -v \"CHANGELOG.md\" | wc -l) >/dev/null && echo 'Only CHANGELOG.md may have uncommitted changes' && exit 1) || exit 0",
-    "clean": "rimraf build",
+    "clean": "rimraf es cjs",
     "lint": "eslint . --ext .js,.jsx",
     "postversion": "git commit package.json CHANGELOG.md -m \"Version $npm_package_version\" && npm run tag && git push && git push --tags && npm publish",
     "prepublish": "in-publish && safe-publish-latest && npm run build || not-in-publish",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "7.3.0",
   "description": "A React component to execute a function whenever you scroll to an element.",
   "main": "build/index.js",
-  "module": "build/index.mjs",
   "types": "index.d.ts",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default [
     ],
     output: [
       { file: pkg.main, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: 'build/index.mjs', format: 'es' }
     ],
     plugins: [
       babel({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default [
     ],
     output: [
       { file: pkg.main, format: 'cjs' },
-      { file: 'build/index.mjs', format: 'es' }
+      { file: 'es/index.mjs', format: 'es' }
     ],
     plugins: [
       babel({


### PR DESCRIPTION
After releasing 7.3.0, we've seen folks run into issues (#221) with the
new `module` field added to package.json. I've tried to read up on how
webpack uses this field, and it looks like it will pick it up by
default. This is tricky because most people will expect a CommonJS
export (i.e. `module.exports = ...`), but now they suddenly have to
import react-waypoints using

  const Waypoint = require('react-waypoint').default;

There's a lengthy issue over at webpack discussing this [1], with a few
proposed solutions at the bottom:

- offer a separate package like lodash does (lodash-es), or
- skip the module field and use a es-specific entry point, like import a from 'yourpkg/es'
- skip the module field, avoid es modules (my preferred solution for most of my modules)

I'm opting for the second point here. We can use the commonjs bundle as
the default, and then if people are adventurous they can point at the es
module directly:

  import Waypoint from 'react-waypoint/build/index.mjs';

We're not really going to the bottom of this issue with this commit. But
I believe it will solve headaches for a lot of applications. For
instance, I just found out that one developer in my team spent time
chasing down a bug where parts of the application wouldn't work.
Waypoints that were imported with `import Waypoint from
'react-waypoint'` were working, but not the ones being imported via
`const Waypoint = require('react-waypoint')` (we have some legacy).

Fixes #221

[1] https://github.com/webpack/webpack/issues/4742