### PR TITLE
Add second arg to Typescript component definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-declare class Waypoint extends React.Component<Waypoint.WaypointProps> {
+declare class Waypoint extends React.Component<Waypoint.WaypointProps, null> {
   above: string;
   below: string;
   inside: string;


### PR DESCRIPTION
JSX elements in Typescript require two args when defined, props and state.  This provides a null arg for state, killing the below Typescript errors:

_Happens when the library is required-_
`[at-loader] ./node_modules/react-waypoint/index.d.ts:3:32
    TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).`

_Happens when library is used -_ 
`[at-loader] ./src/Components/Publishing/Nav/Nav.tsx:73:10
    TS2604: JSX element type 'Waypoint' does not have any construct or call signatures.
`