### PR TITLE
Added module entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.3.4",
   "description": "A React component to execute a function whenever you scroll to an element.",
   "main": "cjs/index.js",
+  "module": "es/index.js",
   "types": "index.d.ts",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default [
     ],
     output: [
       { file: pkg.main, format: 'cjs' },
-      { file: 'es/index.mjs', format: 'es' }
+      { file: pkg.module, format: 'es' }
     ],
     plugins: [
       babel({


### PR DESCRIPTION
Webpack2+ and rollup will understand this out of the box when importing from the lib, no need to import from `'react-waypoint/es'`