### PR TITLE
Type Waypoint class properties as static

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 declare class Waypoint extends React.Component<Waypoint.WaypointProps, {}> {
-  above: string;
-  below: string;
-  inside: string;
-  invisible: string;
+  static above: string;
+  static below: string;
+  static inside: string;
+  static invisible: string;
 }
 
 export = Waypoint;


### PR DESCRIPTION
These properties are set [directly on the constructor](https://github.com/brigade/react-waypoint/blob/master/src/waypoint.jsx#L324-L327), and thus should be static. The current typings cause an error if you attempt to access those properties:

```
Property 'inside' does not exist on type 'typeof Waypoint'.
```