### PR TITLE
Fix import error in typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare class Waypoint extends React.Component<Waypoint.WaypointProps, {}> {
   static invisible: string;
 }
 
-export = Waypoint;
+export default Waypoint;
 
 declare namespace Waypoint {
     interface CallbackArgs {


### PR DESCRIPTION
Fix `export` to es6 syntax in type definition. Used `default export`. If #238 is on purpose, consider this PR

([Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export))