### PR TITLE
Add message to better understand log message in tests

### DIFF
--- a/test/waypoint_test.jsx
+++ b/test/waypoint_test.jsx
@@ -885,6 +885,10 @@ describe('<Waypoint>', function() {
         <div key={3} />,
       ];
 
+      // eslint-disable-next-line no-console
+      console.error('NOTE: Expect an error log below. You can ignore it. ' +
+        "We're testing errors thrown and it seems hard to prevent things " +
+        'from being logged.');
       expect(this.subject).toThrowError(notValidErrorMessage);
 
       window.onerror = prevOnError;


### PR DESCRIPTION
We have a test that verifies that an error is thrown as part of
rendering a waypoint with more than one child. Even though we take
measures to prevent the error from leaking outside the test itself,
Karma picks it up and prints a confusing log:

ERROR: 'The above error occurred in the <Waypoint> component:
    in Waypoint
    in div

No error is logged above that line, which makes it hard to understand.

While it's probably possible to get rid of that line some other way, I
opted for a simple solution to begin with, simply logging something that
makes it A) easier to ignore B) easier to find the offending test case.