### PR TITLE
Allow consolidated-events ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "scrollspy"
   ],
   "dependencies": {
-    "consolidated-events": "^1.1.0",
+    "consolidated-events": "^1.1.0 || ^2.0.0",
     "prop-types": "^15.0.0"
   }
 }


### PR DESCRIPTION
None of the changes affect how consolidated-events is used in
react-waypoint.

Changelog:

- Now built with rollup ([#8](https://github.com/lencioni/consolidated-events/pull/8))
- Deprecated `removeEventListener` export removed ([#13](https://github.com/lencioni/consolidated-events/pull/13))
- Passive event listener test is now removed after being added ([#11](https://github.com/lencioni/consolidated-events/pull/11))
- Reduced bundle size impact by replacing a class with a function ([#12](https://github.com/lencioni/consolidated-events/pull/12))