### PR TITLE
add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 *.gif
+.babelrc
 .eslintignore
 .eslintrc.js
 .overcommit.yml


### PR DESCRIPTION
babel applies whatever config is closest to any given source file, meaning a .babelrc provided by this NPM package will overrule a .babelrc belonging to consumers of this package (who may desire or require different presets and plugins for their app).