### PR TITLE
Stop testing Node 4, explicitly test React versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ node_js:
   - '10'
   - '8'
   - '6'
-  - '4'
 env:
-  - MAIN_RUN=true
-  - MAIN_RUN=false && REACT_VERSION=0.14
-  - MAIN_RUN=false && REACT_VERSION=15.0
+  - REACT_VERSION=0.14.9
+  - REACT_VERSION=15.0
+  - REACT_VERSION=16.0
 before_install:
-  - npm install -g npm@2
+  - npm install -g npm@6.4.1
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - if [[ $MAIN_RUN == false ]]; then npm install react-dom@^$REACT_VERSION react@^$REACT_VERSION; fi
+  - npm install react-dom@^$REACT_VERSION react@^$REACT_VERSION


### PR DESCRIPTION
Node 4 is EOL and should not be used anymore. This removes it from the test suite so that we can speed things up a bit.

I've also started explicitly resting React 16, rather than rely on the fact that our devDependencies have React 16.

I've also made explicit testing against at least React 0.14.9, since we don't support versions of React below that, and since it is pre-major version, npm will treat feature versions as major versions.

Further, this also uses the newest version of npm to do our install which should speed things up a bit. npm version is independent of Node version so this should have no impact other than speedier installs.