### PR TITLE
[Breaking] Remove prop types in production

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": [["airbnb", { "modules": false }]],
-  "plugins": [["transform-react-remove-prop-types", { mode: 'unsafe-wrap' }]]
+  "presets": [["airbnb", { "modules": false }]]
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^6.4.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.12",
     "babel-preset-airbnb": "^2.5.1",
     "eslint": "^3.17.1",
     "eslint-config-brigade": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.0",
     "karma-webpack": "^2.0.3",
+    "loose-envify": "^1.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "rimraf": "^2.6.2",
@@ -75,5 +76,10 @@
     "consolidated-events": "^1.1.0 || ^2.0.0",
     "prop-types": "^15.0.0",
     "react-is": "^16.6.3"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   }
 }

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -315,34 +315,36 @@ export default class Waypoint extends BaseClass {
   }
 }
 
-Waypoint.propTypes = {
-  children: PropTypes.node,
-  debug: PropTypes.bool,
-  onEnter: PropTypes.func,
-  onLeave: PropTypes.func,
-  onPositionChange: PropTypes.func,
-  fireOnRapidScroll: PropTypes.bool,
-  scrollableAncestor: PropTypes.any,
-  horizontal: PropTypes.bool,
+if (process.env.NODE_ENV !== 'production') {
+  Waypoint.propTypes = {
+    children: PropTypes.node,
+    debug: PropTypes.bool,
+    onEnter: PropTypes.func,
+    onLeave: PropTypes.func,
+    onPositionChange: PropTypes.func,
+    fireOnRapidScroll: PropTypes.bool,
+    scrollableAncestor: PropTypes.any,
+    horizontal: PropTypes.bool,
 
-  // `topOffset` can either be a number, in which case its a distance from the
-  // top of the container in pixels, or a string value. Valid string values are
-  // of the form "20px", which is parsed as pixels, or "20%", which is parsed
-  // as a percentage of the height of the containing element.
-  // For instance, if you pass "-20%", and the containing element is 100px tall,
-  // then the waypoint will be triggered when it has been scrolled 20px beyond
-  // the top of the containing element.
-  topOffset: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
+    // `topOffset` can either be a number, in which case its a distance from the
+    // top of the container in pixels, or a string value. Valid string values are
+    // of the form "20px", which is parsed as pixels, or "20%", which is parsed
+    // as a percentage of the height of the containing element.
+    // For instance, if you pass "-20%", and the containing element is 100px tall,
+    // then the waypoint will be triggered when it has been scrolled 20px beyond
+    // the top of the containing element.
+    topOffset: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
 
-  // `bottomOffset` is like `topOffset`, but for the bottom of the container.
-  bottomOffset: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
-};
+    // `bottomOffset` is like `topOffset`, but for the bottom of the container.
+    bottomOffset: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+  };
+}
 
 Waypoint.above = constants.above;
 Waypoint.below = constants.below;


### PR DESCRIPTION
This will shave a few bytes of every production build. A smart bundler might also notice that `prop-types` is unused and removes that dependency but I wouldn't bet on that.