### PR TITLE
Turn the constants into named exports for better minification

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,4 @@
-export default {
-  above: 'above',
-  inside: 'inside',
-  below: 'below',
-  invisible: 'invisible',
-};
+export const ABOVE = 'above';
+export const INSIDE = 'inside';
+export const BELOW = 'below';
+export const INVISIBLE = 'invisible';

--- a/src/getCurrentPosition.js
+++ b/src/getCurrentPosition.js
@@ -1,42 +1,42 @@
-import constants from './constants';
+import { INVISIBLE, INSIDE, BELOW, ABOVE } from './constants';
 
 /**
  * @param {object} bounds An object with bounds data for the waypoint and
  *   scrollable parent
  * @return {string} The current position of the waypoint in relation to the
- *   visible portion of the scrollable parent. One of `constants.above`,
- *   `constants.below`, or `constants.inside`.
+ *   visible portion of the scrollable parent. One of the constants `ABOVE`,
+ *   `BELOW`, `INSIDE` or `INVISIBLE`.
  */
 export default function getCurrentPosition(bounds) {
   if (bounds.viewportBottom - bounds.viewportTop === 0) {
-    return constants.invisible;
+    return INVISIBLE;
   }
 
   // top is within the viewport
   if (bounds.viewportTop <= bounds.waypointTop &&
       bounds.waypointTop <= bounds.viewportBottom) {
-    return constants.inside;
+    return INSIDE;
   }
 
   // bottom is within the viewport
   if (bounds.viewportTop <= bounds.waypointBottom &&
       bounds.waypointBottom <= bounds.viewportBottom) {
-    return constants.inside;
+    return INSIDE;
   }
 
   // top is above the viewport and bottom is below the viewport
   if (bounds.waypointTop <= bounds.viewportTop &&
       bounds.viewportBottom <= bounds.waypointBottom) {
-    return constants.inside;
+    return INSIDE;
   }
 
   if (bounds.viewportBottom < bounds.waypointTop) {
-    return constants.below;
+    return BELOW;
   }
 
   if (bounds.waypointTop < bounds.viewportTop) {
-    return constants.above;
+    return ABOVE;
   }
 
-  return constants.invisible;
+  return INVISIBLE;
 }

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { isForwardRef } from 'react-is';
 
 import computeOffsetPixels from './computeOffsetPixels';
-import constants from './constants';
+import { INVISIBLE, INSIDE, BELOW, ABOVE } from './constants';
 import debugLog from './debugLog';
 import ensureChildrenIsValid from './ensureChildrenIsValid';
 import ensureRefIsUsedByChild from './ensureRefIsUsedByChild';
@@ -210,22 +210,22 @@ export default class Waypoint extends BaseClass {
     };
     this.props.onPositionChange.call(this, callbackArg);
 
-    if (currentPosition === constants.inside) {
+    if (currentPosition === INSIDE) {
       this.props.onEnter.call(this, callbackArg);
-    } else if (previousPosition === constants.inside) {
+    } else if (previousPosition === INSIDE) {
       this.props.onLeave.call(this, callbackArg);
     }
 
-    const isRapidScrollDown = previousPosition === constants.below &&
-      currentPosition === constants.above;
-    const isRapidScrollUp = previousPosition === constants.above &&
-      currentPosition === constants.below;
+    const isRapidScrollDown = previousPosition === BELOW &&
+      currentPosition === ABOVE;
+    const isRapidScrollUp = previousPosition === ABOVE &&
+      currentPosition === BELOW;
 
     if (this.props.fireOnRapidScroll && (isRapidScrollDown || isRapidScrollUp)) {
       // If the scroll event isn't fired often enough to occur while the
       // waypoint was visible, we trigger both callbacks anyway.
       this.props.onEnter.call(this, {
-        currentPosition: constants.inside,
+        currentPosition: INSIDE,
         previousPosition,
         event,
         waypointTop: bounds.waypointTop,
@@ -235,7 +235,7 @@ export default class Waypoint extends BaseClass {
       });
       this.props.onLeave.call(this, {
         currentPosition,
-        previousPosition: constants.inside,
+        previousPosition: INSIDE,
         event,
         waypointTop: bounds.waypointTop,
         waypointBottom: bounds.waypointBottom,
@@ -344,10 +344,10 @@ Waypoint.propTypes = {
   ]),
 };
 
-Waypoint.above = constants.above;
-Waypoint.below = constants.below;
-Waypoint.inside = constants.inside;
-Waypoint.invisible = constants.invisible;
+Waypoint.above = ABOVE;
+Waypoint.below = BELOW;
+Waypoint.inside = INSIDE;
+Waypoint.invisible = INVISIBLE;
 Waypoint.getWindow = () => {
   if (typeof window !== 'undefined') {
     return window;


### PR DESCRIPTION
If you look at the code after rollup ran, you see that the `constants` object is removed in favour of plain variables. This allows a minifier to shorten them to single letter variables instead of something like `c.inside`.

Since `src/constants.js` is not a published file this is not a breaking change.