### PR TITLE
Use external @babel/runtime helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@babel/preset-react": "^7.12.5",
     "@rollup/plugin-babel": "^5.2.1",
     "@types/react": "^16.14.5",
     "babel-loader": "^8.0.0",
@@ -79,6 +80,7 @@
     "scrollspy"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.12.5",
     "consolidated-events": "^1.1.0 || ^2.0.0",
     "prop-types": "^15.0.0",
     "react-is": "^17.0.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import babel from '@rollup/plugin-babel';
+import babel, { getBabelOutputPlugin } from '@rollup/plugin-babel';
 import pkg from './package.json';
 
 export default [
@@ -9,12 +9,34 @@ export default [
       ...Object.keys(pkg.peerDependencies),
     ],
     output: [
-      { file: pkg.main, format: 'cjs' },
-      { file: pkg.module, format: 'es' },
+      {
+        file: pkg.main,
+        format: 'cjs',
+        plugins: [getBabelOutputPlugin({
+          presets: [['airbnb', {
+            modules: false,
+            runtimeVersion: '7.12.5',
+            runtimeHelpersUseESModules: false,
+          }]],
+        })],
+      },
+      {
+        file: pkg.module,
+        format: 'es',
+        plugins: [getBabelOutputPlugin({
+          presets: [['airbnb', {
+            modules: false,
+            runtimeVersion: '7.12.5',
+            runtimeHelpersUseESModules: true,
+          }]],
+        })],
+      },
     ],
     plugins: [
       babel({
+        babelrc: false,
         babelHelpers: 'bundled',
+        presets: ['@babel/preset-react'],
         exclude: ['node_modules/**'],
       }),
     ],


### PR DESCRIPTION
Fixes #302

It does complicate the rollup config quite a bit but this is needed to correctly generate both the ESM and CJS versions.